### PR TITLE
Upgrade toolchain to Gradle 8.13 / AGP 8.13 / Kotlin 2.1.10, fix the pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.11
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Build and Run Tests with Gradle
         run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Upload release
         run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon --no-parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ A version lives in three files and all of them must be bumped together:
 2. `gradle.properties` — `VERSION_NAME`
 3. `history.txt` — one changelog line
 
-Publishing runs from `.github/workflows/publish.yml` on a GitHub release
-(`publishAllPublicationsToMavenCentralRepository`, then `closeAndReleaseRepository`); credentials
-come from repository secrets.
+Publishing runs from `.github/workflows/publish.yml` on a GitHub release; credentials come from
+repository secrets. **The workflow is currently broken**: it still calls the two Gradle tasks the
+maven-publish plugin dropped before 0.34.0, and `SONATYPE_HOST=S01` points at the retired OSSRH
+host. Migrating it to the Central Portal is tracked in issue #9.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this is
+
+`ru.pravbeseda:CurrencyEditText` — an Android library (published to Maven Central) providing two
+views that format numeric/monetary input as the user types:
+
+- `CurrencyEditText` — extends `AppCompatEditText`.
+- `CurrencyMaterialEditText` — extends `TextInputLayout` and wraps a `CurrencyEditText` instance;
+  it delegates almost every method to that inner view and additionally renders validation errors
+  via `TextInputLayout.setError`.
+
+Gradle modules: `:library` (the published artifact) and `:sample` (demo app).
+
+## Build & test
+
+```bash
+./gradlew build                        # what CI runs (JDK 17)
+./gradlew :library:test                # JVM unit tests — the main suite
+./gradlew :library:connectedAndroidTest # instrumented tests, needs a device/emulator
+./gradlew :library:spotlessApply       # format Kotlin (ktlint 1.8.0 + license header)
+./gradlew :library:spotlessCheck
+./gradlew installGitHook               # copies scripts/pre-commit into .git/hooks
+```
+
+Toolchain: Gradle 8.13, AGP 8.13.0, Kotlin 2.1.10, JDK 17 (JDK 21 also works), minSdk 19,
+compileSdk/targetSdk 34. Java source/target stays at 1.8, so `kotlin { compilerOptions { jvmTarget
+= JVM_1_8 } }` is set in both modules to keep the two compilers in step.
+
+## Architecture
+
+Formatting is not done by the views. It lives in one place:
+
+`CurrencyInputWatcher.onTextModified()` (`library/src/main/java/.../watchers/CurrencyInputWatcher.kt`)
+receives the old text, the new text, the inserted fragment and the cursor position, rebuilds the
+whole string (sign → currency prefix → integer part → decimal separator → fractional part) and
+writes it back together with a recalculated cursor position. Nearly every bug and feature in this
+repo is a change to that single function.
+
+Supporting pieces:
+
+- `EasyTextWatcher` — `TextWatcher` with an `ignore` flag so that writing back into the `EditText`
+  does not re-enter the watcher. Subclasses override `onTextModified` only.
+- `CurrencyInputWatcherConfig` — immutable config (locale, separators, currency symbol, max decimal
+  places, negative values, zero padding, `onValueChanged`).
+- `util/Utils.kt` — `parseMoneyValue*`, `formatMoneyValue`, locale/API-level helpers (internal).
+- `util/Routines.kt` — public `Routines.bigDecimalToString(value, CurrencyFormatConfig)` for
+  formatting outside the view; also the `emptyChar = 'n'` sentinel meaning "no grouping separator".
+- `res-public/values/attrs.xml` — XML attributes; `library/build.gradle` adds `src/main/res-public`
+  as a second res source dir.
+
+Conventions that matter when editing the views:
+
+- Separators are resolved once in the watcher's constructor, so **any** config change on the view
+  (`setLocale`, `setSeparators`, `setNegativeValueAllow`, `setMaxNumberOfDecimalPlaces`, …) must go
+  through `invalidateTextWatcher()`, which detaches the old watcher and builds a new one.
+- The currency symbol is stored as a prefix *with a trailing space* (`"$ "`) and is part of the
+  field text; cursor handling in `onSelectionChanged` and in the watcher assumes this.
+- A new XML attribute must be added in three places: `attrs.xml` (both `declare-styleable` blocks),
+  the `init` block of `CurrencyEditText`, and the `init` block + delegating setter/getter of
+  `CurrencyMaterialEditText`.
+
+## Tests
+
+`library/src/test/.../CurrencyInputWatcherTest.kt` is the primary suite. It mocks `EditText` and
+`Editable` with Mockito and asserts the exact `setText`/`setSelection` calls, so a test states both
+the resulting string and the resulting cursor position. Helpers live in `Exts.kt`
+(`runAllWatcherMethods`, `LocaleVars.toWatcher`) and most tests loop over a fixed list of
+`LocaleVars` so behaviour is checked against several separator combinations at once.
+
+Instrumented tests (`src/androidTest`) cover the real views and need a device.
+
+Add a failing test to that suite before changing formatting behaviour.
+
+## Style
+
+- Spotless enforces ktlint 1.8.0, 4-space indent, and the Apache header from `spotless.license.kt`
+  at the top of every `.kt` file — a new file without that header fails the build.
+- Comments and identifiers in English.
+
+## Releasing
+
+A version lives in three files and all of them must be bumped together:
+
+1. `dependencies.gradle` — `publishVersion`, `publishVersionCode`
+2. `gradle.properties` — `VERSION_NAME`
+3. `history.txt` — one changelog line
+
+Publishing runs from `.github/workflows/publish.yml` on a GitHub release
+(`publishAllPublicationsToMavenCentralRepository`, then `closeAndReleaseRepository`); credentials
+come from repository secrets.

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,10 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:4.0.0"
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.24.0'
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:8.9.0"
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # Maven Deployment Variables

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 07 10:27:56 MSK 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply from: '../dependencies.gradle'
 
 android {
+    namespace 'ru.pravbeseda.currencyedittext'
     compileSdk 34
 
     compileOptions {
@@ -30,9 +31,14 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+}
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10'
 
     api 'com.google.android.material:material:1.9.0'
     implementation 'androidx.test:monitor:1.6.1'
@@ -40,8 +46,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core-ktx:1.5.0'
     testImplementation 'androidx.test.ext:junit-ktx:1.1.5'
-    testImplementation 'org.mockito:mockito-core:4.7.0'
-    testImplementation 'org.mockito:mockito-inline:4.7.0'
+    testImplementation 'org.mockito:mockito-core:5.20.0'
 
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:core-ktx:1.5.0'

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,11 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import java.math.BigDecimal
-import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.math.BigDecimal
+import java.util.Locale
 
 class CurrencyEditTextTest {
     // Alternative getting context: private val context: Context = ApplicationProvider.getApplicationContext()
@@ -43,7 +43,7 @@ class CurrencyEditTextTest {
             listOf(
                 arrayOf(BigDecimal(4321.76), "4${groupingSeparator}321${decimalSeparator}76"),
                 arrayOf(BigDecimal(100.0), "100"),
-                arrayOf(BigDecimal(0.0), "0")
+                arrayOf(BigDecimal(0.0), "0"),
             )
         }
         // Run all checks
@@ -113,12 +113,18 @@ class CurrencyEditTextTest {
         }
     }
 
-    private fun setValueAssertEquals(value: BigDecimal, expected: String) {
+    private fun setValueAssertEquals(
+        value: BigDecimal,
+        expected: String,
+    ) {
         setValue(value)
         assertEquals(expected, currencyEditText.text.toString())
     }
 
-    private fun setTextAssertEquals(text: String, expected: String) {
+    private fun setTextAssertEquals(
+        text: String,
+        expected: String,
+    ) {
         setText(text)
         assertEquals(expected, currencyEditText.text.toString())
     }

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -18,7 +18,7 @@ package ru.pravbeseda.currencyedittext
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import java.math.BigDecimal
-import java.util.*
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,12 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import java.util.Locale
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import java.util.Locale
 
-class CurrencyMaterialEditTextTest() {
+class CurrencyMaterialEditTextTest {
     private var context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
     private lateinit var currencyEditText: CurrencyMaterialEditText
@@ -35,12 +35,13 @@ class CurrencyMaterialEditTextTest() {
 
     @Test
     fun shouldSetText() {
-        val samples = listOf(
-            arrayOf("100", "100"),
-            arrayOf("4321.76", "4 321.76"),
-            arrayOf("0.", "0."),
-            arrayOf("", "")
-        )
+        val samples =
+            listOf(
+                arrayOf("100", "100"),
+                arrayOf("4321.76", "4 321.76"),
+                arrayOf("0.", "0."),
+                arrayOf("", ""),
+            )
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             currencyEditText.setSeparators(' ', '.')
         }
@@ -77,7 +78,10 @@ class CurrencyMaterialEditTextTest() {
         testSetText("100.1", "100.1")
     }
 
-    private fun testSetText(text: String, expected: String) {
+    private fun testSetText(
+        text: String,
+        expected: String,
+    ) {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             currencyEditText.setText(text)
         }

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -17,7 +17,7 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import java.util.*
+import java.util.Locale
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="ru.pravbeseda.currencyedittext"/>

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
@@ -25,9 +25,9 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatEditText
 import java.lang.ref.WeakReference
 import java.math.BigDecimal
-import java.util.*
+import java.util.Locale
 import ru.pravbeseda.currencyedittext.model.CurrencyInputWatcherConfig
-import ru.pravbeseda.currencyedittext.util.*
+import ru.pravbeseda.currencyedittext.util.firstChar
 import ru.pravbeseda.currencyedittext.util.formatMoneyValue
 import ru.pravbeseda.currencyedittext.util.getLocaleFromTag
 import ru.pravbeseda.currencyedittext.util.isLollipopAndAbove

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,9 +23,6 @@ import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
 import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatEditText
-import java.lang.ref.WeakReference
-import java.math.BigDecimal
-import java.util.Locale
 import ru.pravbeseda.currencyedittext.model.CurrencyInputWatcherConfig
 import ru.pravbeseda.currencyedittext.util.firstChar
 import ru.pravbeseda.currencyedittext.util.formatMoneyValue
@@ -33,10 +30,13 @@ import ru.pravbeseda.currencyedittext.util.getLocaleFromTag
 import ru.pravbeseda.currencyedittext.util.isLollipopAndAbove
 import ru.pravbeseda.currencyedittext.util.parseMoneyValueWithLocale
 import ru.pravbeseda.currencyedittext.watchers.CurrencyInputWatcher
+import java.lang.ref.WeakReference
+import java.math.BigDecimal
+import java.util.Locale
 
 open class CurrencyEditText(
     context: Context,
-    attrs: AttributeSet?
+    attrs: AttributeSet?,
 ) : AppCompatEditText(context, attrs) {
     private lateinit var currencySymbolPrefix: String // lateinit is important!
     private var textWatcher: CurrencyInputWatcher
@@ -73,32 +73,33 @@ open class CurrencyEditText(
         textDirection = TEXT_DIRECTION_LTR
         var localeTag: String?
         val prefix: String
-        context.theme.obtainStyledAttributes(
-            attrs,
-            R.styleable.CurrencyEditText,
-            0,
-            0
-        ).run {
-            try {
-                prefix = getString(R.styleable.CurrencyEditText_currencySymbol).orEmpty()
-                localeTag = getString(R.styleable.CurrencyEditText_localeTag)
-                decimalSeparator =
-                    getString(R.styleable.CurrencyEditText_decimalSeparator).firstChar()
-                groupingSeparator =
-                    getString(R.styleable.CurrencyEditText_groupingSeparator).firstChar()
-                useCurrencySymbolAsHint =
-                    getBoolean(R.styleable.CurrencyEditText_useCurrencySymbolAsHint, false)
-                maxDecimalPlaces = getInt(R.styleable.CurrencyEditText_maxNumberOfDecimalPlaces, 2)
-                negativeValueAllow =
-                    getBoolean(R.styleable.CurrencyEditText_negativeValueAllow, false)
-                decimalZerosPadding =
-                    getBoolean(R.styleable.CurrencyEditText_decimalZerosPadding, false)
-                emptyStringForZero =
-                    getBoolean(R.styleable.CurrencyEditText_emptyStringForZero, true)
-            } finally {
-                recycle()
+        context.theme
+            .obtainStyledAttributes(
+                attrs,
+                R.styleable.CurrencyEditText,
+                0,
+                0,
+            ).run {
+                try {
+                    prefix = getString(R.styleable.CurrencyEditText_currencySymbol).orEmpty()
+                    localeTag = getString(R.styleable.CurrencyEditText_localeTag)
+                    decimalSeparator =
+                        getString(R.styleable.CurrencyEditText_decimalSeparator).firstChar()
+                    groupingSeparator =
+                        getString(R.styleable.CurrencyEditText_groupingSeparator).firstChar()
+                    useCurrencySymbolAsHint =
+                        getBoolean(R.styleable.CurrencyEditText_useCurrencySymbolAsHint, false)
+                    maxDecimalPlaces = getInt(R.styleable.CurrencyEditText_maxNumberOfDecimalPlaces, 2)
+                    negativeValueAllow =
+                        getBoolean(R.styleable.CurrencyEditText_negativeValueAllow, false)
+                    decimalZerosPadding =
+                        getBoolean(R.styleable.CurrencyEditText_decimalZerosPadding, false)
+                    emptyStringForZero =
+                        getBoolean(R.styleable.CurrencyEditText_emptyStringForZero, true)
+                } finally {
+                    recycle()
+                }
             }
-        }
         currencySymbolPrefix = if (prefix.isBlank()) "" else "$prefix "
         if (useCurrencySymbolAsHint) hint = currencySymbolPrefix
         if (isLollipopAndAbove() && !localeTag.isNullOrBlank()) {
@@ -119,14 +120,12 @@ open class CurrencyEditText(
             formatMoneyValue(
                 value,
                 textWatcher.getGroupingSeparator(),
-                textWatcher.getDecimalSeparator()
-            )
+                textWatcher.getDecimalSeparator(),
+            ),
         )
     }
 
-    fun getValue(): BigDecimal {
-        return stringToBigDecimal(text.toString())
-    }
+    fun getValue(): BigDecimal = stringToBigDecimal(text.toString())
 
     fun setLocale(locale: Locale) {
         val value = getValue()
@@ -145,7 +144,10 @@ open class CurrencyEditText(
         setValue(value)
     }
 
-    fun setSeparators(newGroupingSeparator: Char, newDecimalSeparator: Char) {
+    fun setSeparators(
+        newGroupingSeparator: Char,
+        newDecimalSeparator: Char,
+    ) {
         var decimal = newDecimalSeparator
         if (newGroupingSeparator == newDecimalSeparator) {
             decimal = if (newDecimalSeparator == '.') ',' else '.'
@@ -158,42 +160,35 @@ open class CurrencyEditText(
         setValue(value)
     }
 
-    fun getDecimalSeparator(): Char {
-        return textWatcher.getDecimalSeparator()
-    }
+    fun getDecimalSeparator(): Char = textWatcher.getDecimalSeparator()
 
-    fun getGroupingSeparator(): Char {
-        return textWatcher.getGroupingSeparator()
-    }
+    fun getGroupingSeparator(): Char = textWatcher.getGroupingSeparator()
 
     fun setNegativeValueAllow(newValue: Boolean) {
         negativeValueAllow = newValue
         invalidateTextWatcher()
     }
 
-    fun getNegativeValueAllow(): Boolean {
-        return negativeValueAllow
-    }
+    fun getNegativeValueAllow(): Boolean = negativeValueAllow
 
     fun setDecimalZerosPadding(newValue: Boolean) {
         decimalZerosPadding = newValue
         invalidateTextWatcher()
     }
 
-    fun getDecimalZerosPadding(): Boolean {
-        return decimalZerosPadding
-    }
+    fun getDecimalZerosPadding(): Boolean = decimalZerosPadding
 
     fun setEmptyStringForZero(newValue: Boolean) {
         emptyStringForZero = newValue
         setValue(getValue())
     }
 
-    fun getEmptyStringForZero(): Boolean {
-        return emptyStringForZero
-    }
+    fun getEmptyStringForZero(): Boolean = emptyStringForZero
 
-    fun setCurrencySymbol(currencySymbol: String, useCurrencySymbolAsHint: Boolean = false) {
+    fun setCurrencySymbol(
+        currencySymbol: String,
+        useCurrencySymbolAsHint: Boolean = false,
+    ) {
         currencySymbolPrefix = "$currencySymbol "
         if (useCurrencySymbolAsHint) hint = currencySymbolPrefix
         invalidateTextWatcher()
@@ -204,9 +199,7 @@ open class CurrencyEditText(
         invalidateTextWatcher()
     }
 
-    fun isValidState(): Boolean {
-        return state == State.OK
-    }
+    fun isValidState(): Boolean = state == State.OK
 
     private fun invalidateTextWatcher() {
         removeTextChangedListener(textWatcher)
@@ -215,53 +208,61 @@ open class CurrencyEditText(
     }
 
     private fun createTextWatcher(): CurrencyInputWatcher {
-        val config = CurrencyInputWatcherConfig(
-            locale = locale,
-            currencySymbol = currencySymbolPrefix,
-            decimalSeparator = decimalSeparator,
-            groupingSeparator = groupingSeparator,
-            maxNumberOfDecimalPlaces = maxDecimalPlaces,
-            negativeValueAllow = negativeValueAllow,
-            decimalZerosPadding = decimalZerosPadding,
-            onValueChanged = {
-                val value = stringToBigDecimal(it)
-                validate(value)
-                onValueChanged?.onValueChanged(value, state, textError)
-            }
-        )
+        val config =
+            CurrencyInputWatcherConfig(
+                locale = locale,
+                currencySymbol = currencySymbolPrefix,
+                decimalSeparator = decimalSeparator,
+                groupingSeparator = groupingSeparator,
+                maxNumberOfDecimalPlaces = maxDecimalPlaces,
+                negativeValueAllow = negativeValueAllow,
+                decimalZerosPadding = decimalZerosPadding,
+                onValueChanged = {
+                    val value = stringToBigDecimal(it)
+                    validate(value)
+                    onValueChanged?.onValueChanged(value, state, textError)
+                },
+            )
         return CurrencyInputWatcher(
             WeakReference(this),
-            config
+            config,
         )
     }
 
     fun validate(value: BigDecimal? = null) {
         val checkedValue = value ?: getValue()
         textError = (validator?.let { it1 -> it1(checkedValue) }) ?: ""
-        state = if (textError.isEmpty()) {
-            State.OK
-        } else {
-            State.ERROR
-        }
+        state =
+            if (textError.isEmpty()) {
+                State.OK
+            } else {
+                State.ERROR
+            }
     }
 
-    private fun stringToBigDecimal(str: String?): BigDecimal {
-        return BigDecimal(
+    private fun stringToBigDecimal(str: String?): BigDecimal =
+        BigDecimal(
             parseMoneyValueWithLocale(
                 str ?: "",
                 textWatcher.getGroupingSeparator(),
                 textWatcher.getDecimalSeparator(),
-                currencySymbolPrefix
-            ).toString()
+                currencySymbolPrefix,
+            ).toString(),
         )
-    }
 
-    override fun setText(text: CharSequence?, type: BufferType?) {
+    override fun setText(
+        text: CharSequence?,
+        type: BufferType?,
+    ) {
         super.setText(text, type)
         getText()?.length?.let { setSelection(it) }
     }
 
-    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+    override fun onFocusChanged(
+        focused: Boolean,
+        direction: Int,
+        previouslyFocusedRect: Rect?,
+    ) {
         super.onFocusChanged(focused, direction, previouslyFocusedRect)
         if (focused) {
             removeTextChangedListener(textWatcher)
@@ -273,7 +274,10 @@ open class CurrencyEditText(
         }
     }
 
-    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+    override fun onSelectionChanged(
+        selStart: Int,
+        selEnd: Int,
+    ) {
         if (::currencySymbolPrefix.isInitialized.not()) return
         val symbolLength = currencySymbolPrefix.length
         if (selEnd < symbolLength && text.toString().length >= symbolLength) {
@@ -285,12 +289,17 @@ open class CurrencyEditText(
 
     fun onValueChanged(action: (BigDecimal, state: State, textError: String) -> Unit) {
         val that = this
-        onValueChanged = object : OnValueChanged {
-            override fun onValueChanged(newValue: BigDecimal, state: State, textError: String) {
-                that.state = state
-                action.invoke(newValue, state, textError)
+        onValueChanged =
+            object : OnValueChanged {
+                override fun onValueChanged(
+                    newValue: BigDecimal,
+                    state: State,
+                    textError: String,
+                ) {
+                    that.state = state
+                    action.invoke(newValue, state, textError)
+                }
             }
-        }
     }
 
     fun setValidator(newValidator: ((BigDecimal) -> String?)?) {
@@ -301,7 +310,11 @@ open class CurrencyEditText(
      * Interface for value and state change callback
      */
     interface OnValueChanged {
-        fun onValueChanged(newValue: BigDecimal, state: State, textError: String)
+        fun onValueChanged(
+            newValue: BigDecimal,
+            state: State,
+            textError: String,
+        )
     }
 
     companion object {
@@ -310,7 +323,7 @@ open class CurrencyEditText(
          */
         enum class State {
             OK, // Valid
-            ERROR // Invalid value
+            ERROR, // Invalid value
         }
     }
 }

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,16 +21,17 @@ import android.text.Editable
 import android.util.AttributeSet
 import androidx.annotation.RequiresApi
 import com.google.android.material.textfield.TextInputLayout
-import java.math.BigDecimal
-import java.util.Locale
 import ru.pravbeseda.currencyedittext.util.firstChar
 import ru.pravbeseda.currencyedittext.util.getLocaleFromTag
 import ru.pravbeseda.currencyedittext.util.isApi26AndAbove
 import ru.pravbeseda.currencyedittext.util.isLollipopAndAbove
+import java.math.BigDecimal
+import java.util.Locale
 
-open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
-    TextInputLayout(context, attrs) {
-
+open class CurrencyMaterialEditText(
+    context: Context,
+    attrs: AttributeSet?,
+) : TextInputLayout(context, attrs) {
     var text: Editable?
         get() {
             return editText.text
@@ -63,36 +64,38 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         var maxDecimalPlaces: Int
         var decimalZerosPadding: Boolean
         var emptyStringForZero: Boolean
-        context.theme.obtainStyledAttributes(
-            attrs,
-            R.styleable.CurrencyMaterialEditText,
-            0,
-            0
-        ).run {
-            localeTag = getString(R.styleable.CurrencyMaterialEditText_localeTag)
-            text = getString(R.styleable.CurrencyMaterialEditText_text)
-            decimalSeparator =
-                getString(R.styleable.CurrencyMaterialEditText_decimalSeparator).firstChar()
-            groupingSeparator =
-                getString(R.styleable.CurrencyMaterialEditText_groupingSeparator).firstChar()
-            negativeValueAllow = getBoolean(
-                R.styleable.CurrencyMaterialEditText_negativeValueAllow,
-                false
-            )
-            decimalZerosPadding =
-                getBoolean(R.styleable.CurrencyMaterialEditText_decimalZerosPadding, false)
-            selectAllOnFocus =
-                getBoolean(R.styleable.CurrencyMaterialEditText_selectAllOnFocus, false)
-            maxDecimalPlaces =
-                getInt(R.styleable.CurrencyMaterialEditText_maxNumberOfDecimalPlaces, 2)
-            emptyStringForZero =
-                getBoolean(R.styleable.CurrencyMaterialEditText_emptyStringForZero, true)
-        }
+        context.theme
+            .obtainStyledAttributes(
+                attrs,
+                R.styleable.CurrencyMaterialEditText,
+                0,
+                0,
+            ).run {
+                localeTag = getString(R.styleable.CurrencyMaterialEditText_localeTag)
+                text = getString(R.styleable.CurrencyMaterialEditText_text)
+                decimalSeparator =
+                    getString(R.styleable.CurrencyMaterialEditText_decimalSeparator).firstChar()
+                groupingSeparator =
+                    getString(R.styleable.CurrencyMaterialEditText_groupingSeparator).firstChar()
+                negativeValueAllow =
+                    getBoolean(
+                        R.styleable.CurrencyMaterialEditText_negativeValueAllow,
+                        false,
+                    )
+                decimalZerosPadding =
+                    getBoolean(R.styleable.CurrencyMaterialEditText_decimalZerosPadding, false)
+                selectAllOnFocus =
+                    getBoolean(R.styleable.CurrencyMaterialEditText_selectAllOnFocus, false)
+                maxDecimalPlaces =
+                    getInt(R.styleable.CurrencyMaterialEditText_maxNumberOfDecimalPlaces, 2)
+                emptyStringForZero =
+                    getBoolean(R.styleable.CurrencyMaterialEditText_emptyStringForZero, true)
+            }
         if (isLollipopAndAbove() && !localeTag.isNullOrBlank()) {
             setLocale(
                 getLocaleFromTag(
-                    localeTag!!
-                )
+                    localeTag!!,
+                ),
             )
         }
         if (isApi26AndAbove()) {
@@ -103,7 +106,7 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         if (decimalSeparator !== null && groupingSeparator !== null) {
             setSeparators(
                 groupingSeparator!!,
-                decimalSeparator!!
+                decimalSeparator!!,
             )
         }
         setNegativeValueAllow(negativeValueAllow)
@@ -118,9 +121,7 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         editText.setValue(value)
     }
 
-    fun getValue(): BigDecimal {
-        return editText.getValue()
-    }
+    fun getValue(): BigDecimal = editText.getValue()
 
     fun setText(text: CharSequence) {
         editText.setText(text)
@@ -135,7 +136,10 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         editText.setLocale(localeTag)
     }
 
-    fun setSeparators(newGroupingSeparator: Char, newDecimalSeparator: Char) {
+    fun setSeparators(
+        newGroupingSeparator: Char,
+        newDecimalSeparator: Char,
+    ) {
         editText.setSeparators(newGroupingSeparator, newDecimalSeparator)
     }
 
@@ -147,33 +151,25 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         editText.setMaxNumberOfDecimalPlaces(maxDecimalPlaces)
     }
 
-    fun getNegativeValueAllow(): Boolean {
-        return editText.getNegativeValueAllow()
-    }
+    fun getNegativeValueAllow(): Boolean = editText.getNegativeValueAllow()
 
     fun setNegativeValueAllow(allow: Boolean) {
         editText.setNegativeValueAllow(allow)
     }
 
-    fun getDecimalZerosPadding(): Boolean {
-        return editText.getDecimalZerosPadding()
-    }
+    fun getDecimalZerosPadding(): Boolean = editText.getDecimalZerosPadding()
 
     fun setDecimalZerosPadding(padding: Boolean) {
         editText.setDecimalZerosPadding(padding)
     }
 
-    fun getEmptyStringForZero(): Boolean {
-        return editText.getEmptyStringForZero()
-    }
+    fun getEmptyStringForZero(): Boolean = editText.getEmptyStringForZero()
 
     fun setEmptyStringForZero(newValue: Boolean) {
         editText.setEmptyStringForZero(newValue)
     }
 
-    fun onValueChanged(
-        action: (BigDecimal?, state: CurrencyEditText.Companion.State, textError: String) -> Unit
-    ) {
+    fun onValueChanged(action: (BigDecimal?, state: CurrencyEditText.Companion.State, textError: String) -> Unit) {
         editText.onValueChanged(action)
     }
 
@@ -185,13 +181,11 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
         editText.validate()
     }
 
-    fun isValidState(): Boolean {
-        return editText.isValidState()
-    }
+    fun isValidState(): Boolean = editText.isValidState()
 
     // wrapper fo validate function to add some logic
-    private fun handleValidator(validate: ((BigDecimal) -> String?)?): (BigDecimal) -> String? {
-        return { input: BigDecimal ->
+    private fun handleValidator(validate: ((BigDecimal) -> String?)?): (BigDecimal) -> String? =
+        { input: BigDecimal ->
             val result = if (validate !== null) validate(input) else null
             if (result != null) {
                 // set TextInputLayout property to show error description
@@ -199,5 +193,4 @@ open class CurrencyMaterialEditText(context: Context, attrs: AttributeSet?) :
             }
             result
         }
-    }
 }

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import androidx.annotation.RequiresApi
 import com.google.android.material.textfield.TextInputLayout
 import java.math.BigDecimal
-import java.util.*
+import java.util.Locale
 import ru.pravbeseda.currencyedittext.util.firstChar
 import ru.pravbeseda.currencyedittext.util.getLocaleFromTag
 import ru.pravbeseda.currencyedittext.util.isApi26AndAbove

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyFormatConfig.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyFormatConfig.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,5 +22,5 @@ data class CurrencyFormatConfig(
     val groupingSeparator: Char = DecimalFormatSymbols().groupingSeparator,
     val decimalLength: Int = 2,
     val showPlusSign: Boolean = false,
-    val addLTRPrefix: Boolean = false
+    val addLTRPrefix: Boolean = false,
 )

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig.kt
@@ -15,7 +15,7 @@
  */
 package ru.pravbeseda.currencyedittext.model
 
-import java.util.*
+import java.util.Locale
 
 data class CurrencyInputWatcherConfig(
     val locale: Locale = Locale.getDefault(),

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,5 +25,5 @@ data class CurrencyInputWatcherConfig(
     val maxNumberOfDecimalPlaces: Int = 2,
     val decimalZerosPadding: Boolean = false,
     val negativeValueAllow: Boolean = false,
-    val onValueChanged: ((String?) -> Unit)? = null
+    val onValueChanged: ((String?) -> Unit)? = null,
 )

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/CurrencyRounder.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/CurrencyRounder.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,12 +31,13 @@ package ru.pravbeseda.currencyedittext.util
 fun truncateNumberToMaxDecimalDigits(
     number: String,
     maxDecimalDigits: Int,
-    decimalSeparator: Char
+    decimalSeparator: Char,
 ): String {
     // Split number into whole and decimal part
-    val arr = number
-        .split(decimalSeparator)
-        .toMutableList()
+    val arr =
+        number
+            .split(decimalSeparator)
+            .toMutableList()
 
     // We should have exactly 2 elements in our string;
     // the whole part and the decimal part

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
@@ -21,6 +21,8 @@ import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
 
+// Public API since 1.0: renaming it to EMPTY_CHAR would break consumers.
+@Suppress("ktlint:standard:property-naming")
 const val emptyChar = 'n' // from null
 
 class Routines {

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,11 @@
  */
 package ru.pravbeseda.currencyedittext.util
 
+import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
-import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
 
 // Public API since 1.0: renaming it to EMPTY_CHAR would break consumers.
 @Suppress("ktlint:standard:property-naming")
@@ -27,7 +27,10 @@ const val emptyChar = 'n' // from null
 
 class Routines {
     companion object {
-        fun bigDecimalToString(value: BigDecimal, config: CurrencyFormatConfig): String {
+        fun bigDecimalToString(
+            value: BigDecimal,
+            config: CurrencyFormatConfig,
+        ): String {
             val symbols = DecimalFormatSymbols()
             symbols.zeroDigit = '0'
             symbols.digit = '0'
@@ -51,6 +54,4 @@ class Routines {
     }
 }
 
-fun String?.firstChar(): Char? {
-    return if (!this.isNullOrEmpty()) this[0] else null
-}
+fun String?.firstChar(): Char? = if (!this.isNullOrEmpty()) this[0] else null

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/Utils.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/Utils.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,9 +29,10 @@ internal fun parseMoneyValue(
     value: String,
     groupingSeparator: Char,
     decimalSeparator: Char,
-    currencySymbol: String
+    currencySymbol: String,
 ): String =
-    value.replace(currencySymbol, "")
+    value
+        .replace(currencySymbol, "")
         .replace(groupingSeparator.toString(), "")
         .replace(decimalSeparator.toString(), ".")
 
@@ -39,7 +40,7 @@ internal fun parseMoneyValueWithLocale(
     value: String,
     groupingSeparator: Char,
     decimalSeparator: Char,
-    currencySymbol: String
+    currencySymbol: String,
 ): Number {
     val valueWithoutSeparator =
         parseMoneyValue(value, groupingSeparator, decimalSeparator, currencySymbol)
@@ -53,7 +54,7 @@ internal fun parseMoneyValueWithLocale(
 internal fun formatMoneyValue(
     value: BigDecimal,
     groupingSeparator: Char,
-    decimalSeparator: Char
+    decimalSeparator: Char,
 ): String {
     val symbols = DecimalFormatSymbols(Locale.ROOT)
     symbols.decimalSeparator = decimalSeparator
@@ -63,13 +64,13 @@ internal fun formatMoneyValue(
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-internal fun getLocaleFromTag(localeTag: String): Locale {
-    return try {
+internal fun getLocaleFromTag(localeTag: String): Locale =
+    try {
         Locale.Builder().setLanguageTag(localeTag).build()
     } catch (e: IllformedLocaleException) {
         Locale.getDefault()
     }
-}
 
 internal fun isLollipopAndAbove(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+
 internal fun isApi26AndAbove(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/watchers/CurrencyInputWatcher.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/watchers/CurrencyInputWatcher.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,13 +23,12 @@ import java.text.DecimalFormatSymbols
 
 class CurrencyInputWatcher(
     private val editTextRef: WeakReference<EditText>,
-    private val config: CurrencyInputWatcherConfig
+    private val config: CurrencyInputWatcherConfig,
 ) : EasyTextWatcher() {
-
     init {
         if (config.maxNumberOfDecimalPlaces < 0) {
             throw IllegalArgumentException(
-                "Maximum number of Decimal Places must be a positive integer"
+                "Maximum number of Decimal Places must be a positive integer",
             )
         }
     }
@@ -53,7 +52,7 @@ class CurrencyInputWatcher(
         newPartOfText: String?,
         newText: String?,
         oldText: String?,
-        editPosition: Int?
+        editPosition: Int?,
     ) {
         var resultText: String = newText ?: ""
         var sign = ""
@@ -62,7 +61,7 @@ class CurrencyInputWatcher(
         // Replace inserted comma or point to decimalSeparator
         if (arrayOf(
                 ",",
-                "."
+                ".",
             ).contains(newPartOfText) && newPartOfText != decimalSeparator.toString()
         ) {
             resultText =
@@ -105,7 +104,8 @@ class CurrencyInputWatcher(
         // Prevent manual removing currency symbol
         if (!resultText.startsWith(config.currencySymbol)) {
             resultText =
-                config.currencySymbol + resultText.trimStart {
+                config.currencySymbol +
+                resultText.trimStart {
                     config.currencySymbol.toCharArray().contains(it)
                 }
         }
@@ -129,26 +129,29 @@ class CurrencyInputWatcher(
         val decimalSeparatorPos = newTextWithoutGroupingSeparators.indexOf(decimalSeparator)
 
         // Cursor position calculation (in text without separators)
-        var cursorPosition = position.let {
-            val end = if (it > resultText.length) resultText.length else it
-            val text = resultText.substring(0, end)
-            val curSpaceCount = countMatches(text, groupingSeparator.toString())
-            val spaceCountInCurrencySymbol =
-                countMatches(config.currencySymbol, groupingSeparator.toString())
-            it - curSpaceCount + spaceCountInCurrencySymbol
-        }
+        var cursorPosition =
+            position.let {
+                val end = if (it > resultText.length) resultText.length else it
+                val text = resultText.substring(0, end)
+                val curSpaceCount = countMatches(text, groupingSeparator.toString())
+                val spaceCountInCurrencySymbol =
+                    countMatches(config.currencySymbol, groupingSeparator.toString())
+                it - curSpaceCount + spaceCountInCurrencySymbol
+            }
 
-        var integerPart = if (decimalSeparatorPos == -1) {
-            newTextWithoutGroupingSeparators
-        } else {
-            newTextWithoutGroupingSeparators.substring(0, decimalSeparatorPos)
-        }
+        var integerPart =
+            if (decimalSeparatorPos == -1) {
+                newTextWithoutGroupingSeparators
+            } else {
+                newTextWithoutGroupingSeparators.substring(0, decimalSeparatorPos)
+            }
 
-        var fractionalPart = if (decimalSeparatorPos == -1) {
-            ""
-        } else {
-            newTextWithoutGroupingSeparators.substring(decimalSeparatorPos + 1)
-        }
+        var fractionalPart =
+            if (decimalSeparatorPos == -1) {
+                ""
+            } else {
+                newTextWithoutGroupingSeparators.substring(decimalSeparatorPos + 1)
+            }
         if (fractionalPart.length > config.maxNumberOfDecimalPlaces) {
             fractionalPart = fractionalPart.substring(0, config.maxNumberOfDecimalPlaces)
         }
@@ -189,15 +192,14 @@ class CurrencyInputWatcher(
         setText(resultText, cursorPosition, config.currencySymbol, sign)
     }
 
-    fun getDecimalSeparator(): Char {
-        return decimalSeparator
-    }
+    fun getDecimalSeparator(): Char = decimalSeparator
 
-    fun getGroupingSeparator(): Char {
-        return groupingSeparator
-    }
+    fun getGroupingSeparator(): Char = groupingSeparator
 
-    private fun countMatches(string: String?, pattern: String): Int {
+    private fun countMatches(
+        string: String?,
+        pattern: String,
+    ): Int {
         if (string.isNullOrEmpty()) {
             return 0
         }
@@ -209,15 +211,16 @@ class CurrencyInputWatcher(
         resultText: String?,
         resultEditPosition: Int?,
         currencySymbol: String,
-        sign: String
+        sign: String,
     ) {
         // Format text
-        val (text, position) = calculateSpacing(
-            resultText = resultText,
-            resultEditPosition = resultEditPosition,
-            currencySymbol,
-            sign
-        )
+        val (text, position) =
+            calculateSpacing(
+                resultText = resultText,
+                resultEditPosition = resultEditPosition,
+                currencySymbol,
+                sign,
+            )
 
         editText?.setText((text as? String?) ?: "")
 
@@ -231,22 +234,24 @@ class CurrencyInputWatcher(
         resultText: String?,
         resultEditPosition: Int?,
         currencySymbol: String,
-        sign: String
+        sign: String,
     ): Array<Any?> {
         var resultPosition = resultEditPosition ?: currencySymbol.length
         val dotPos = resultText?.indexOf(decimalSeparator) ?: -1
 
-        var textBeforeDot = if (dotPos == -1) {
-            resultText ?: ""
-        } else {
-            resultText?.substring(0, dotPos) ?: ""
-        }
+        var textBeforeDot =
+            if (dotPos == -1) {
+                resultText ?: ""
+            } else {
+                resultText?.substring(0, dotPos) ?: ""
+            }
 
-        var textAfterDot = if (dotPos == -1) {
-            null
-        } else {
-            resultText?.substring(dotPos + 1, resultText.length) ?: ""
-        }
+        var textAfterDot =
+            if (dotPos == -1) {
+                null
+            } else {
+                resultText?.substring(dotPos + 1, resultText.length) ?: ""
+            }
 
         val spaceCount = textBeforeDot.length / 3
 
@@ -267,11 +272,12 @@ class CurrencyInputWatcher(
             }
         }
 
-        textAfterDot = if (textAfterDot != null) {
-            "$decimalSeparator$textAfterDot"
-        } else {
-            ""
-        }
+        textAfterDot =
+            if (textAfterDot != null) {
+                "$decimalSeparator$textAfterDot"
+            } else {
+                ""
+            }
 
         // Final result
         val result = currencySymbol + sign + textBeforeDot + textAfterDot

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/watchers/EasyTextWatcher.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/watchers/EasyTextWatcher.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,11 +34,21 @@ abstract class EasyTextWatcher : TextWatcher {
     // Cursor position after changing text
     private var editPosition: Int? = null
 
-    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+    override fun beforeTextChanged(
+        s: CharSequence?,
+        start: Int,
+        count: Int,
+        after: Int,
+    ) {
         oldText = s.toString()
     }
 
-    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+    override fun onTextChanged(
+        s: CharSequence?,
+        start: Int,
+        before: Int,
+        count: Int,
+    ) {
         modifiedText = s.toString()
         newPartOfText = modifiedText!!.substring(start, start + count)
         editPosition = start + count
@@ -51,7 +61,7 @@ abstract class EasyTextWatcher : TextWatcher {
                 newPartOfText = newPartOfText,
                 newText = modifiedText,
                 oldText = oldText,
-                editPosition = editPosition
+                editPosition = editPosition,
             )
             endEditing()
         }
@@ -76,6 +86,6 @@ abstract class EasyTextWatcher : TextWatcher {
         newPartOfText: String?,
         newText: String?,
         oldText: String?,
-        editPosition: Int?
+        editPosition: Int?,
     )
 }

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/CurrencyInputWatcherTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/CurrencyInputWatcherTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,14 +29,14 @@ import ru.pravbeseda.currencyedittext.watchers.CurrencyInputWatcher
 import java.lang.ref.WeakReference
 
 class CurrencyInputWatcherTest {
-
-    private val locales = listOf(
-        LocaleVars("en-NG", '.', ',', "$ "),
-        LocaleVars("en-US", '.', ',', "$ "),
-        LocaleVars("da-DK", ',', '.', "$ "),
-        LocaleVars("fr-CA", '.', ' ', "$ "),
-        LocaleVars("ru-Ru", ',', ' ', "")
-    )
+    private val locales =
+        listOf(
+            LocaleVars("en-NG", '.', ',', "$ "),
+            LocaleVars("en-US", '.', ',', "$ "),
+            LocaleVars("da-DK", ',', '.', "$ "),
+            LocaleVars("fr-CA", '.', ' ', "$ "),
+            LocaleVars("ru-Ru", ',', ' ', ""),
+        )
 
     @Test
     fun `Should keep currency symbol as hint when enabled and move cursor to front when edit text is set to empty string`() {
@@ -184,7 +184,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 start,
                 1,
-                start + 1
+                start + 1,
             )
             watcher.onTextChanged(editable, start, 0, 1)
             watcher.afterTextChanged(editable)
@@ -244,7 +244,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentEditTextContent.length,
                 1,
-                currentEditTextContent.length + 1
+                currentEditTextContent.length + 1,
             )
             watcher.onTextChanged(editable, currentEditTextContent.length, 0, 1)
             watcher.afterTextChanged(editable)
@@ -335,17 +335,19 @@ class CurrencyInputWatcherTest {
                 "${locale.currencySymbol}1${locale.groupingSeparator}320${locale.decimalSeparator}50"
 
             val (editText, editable) = setupTestVariables(locale)
-            val config = CurrencyInputWatcherConfig(
-                currencySymbol = locale.currencySymbol,
-                locale = locale.tag.toLocale(),
-                decimalSeparator = locale.decimalSeparator,
-                groupingSeparator = locale.groupingSeparator,
-                maxNumberOfDecimalPlaces = 2
-            )
-            val watcherWithDefaultDP = CurrencyInputWatcher(
-                WeakReference(editText),
-                config
-            )
+            val config =
+                CurrencyInputWatcherConfig(
+                    currencySymbol = locale.currencySymbol,
+                    locale = locale.tag.toLocale(),
+                    decimalSeparator = locale.decimalSeparator,
+                    groupingSeparator = locale.groupingSeparator,
+                    maxNumberOfDecimalPlaces = 2,
+                )
+            val watcherWithDefaultDP =
+                CurrencyInputWatcher(
+                    WeakReference(editText),
+                    config,
+                )
             `when`(editable.toString()).thenReturn(currentEditTextContent)
 
             watcherWithDefaultDP.runAllWatcherMethods(editable)
@@ -461,13 +463,14 @@ class CurrencyInputWatcherTest {
                 "${locale.currencySymbol}1${locale.groupingSeparator}320${locale.decimalSeparator}519"
 
             val (editText, editable, watcher) = setupTestVariables(locale, decimalPlaces = 2)
-            val secondWatcher = locale.toWatcher(
-                editText,
-                3,
-                locale.decimalSeparator,
-                locale.groupingSeparator,
-                false
-            )
+            val secondWatcher =
+                locale.toWatcher(
+                    editText,
+                    3,
+                    locale.decimalSeparator,
+                    locale.groupingSeparator,
+                    false,
+                )
             `when`(editable.toString()).thenReturn(currentEditTextContent)
 
             watcher.runAllWatcherMethods(editable)
@@ -509,7 +512,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 locale.currencySymbol.length + 1,
                 1,
-                locale.currencySymbol.length + 2
+                locale.currencySymbol.length + 2,
             )
             watcher.onTextChanged(editable, locale.currencySymbol.length + 1, 0, 1)
             watcher.afterTextChanged(editable)
@@ -533,7 +536,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentEditTextContent.length,
                 0,
-                1
+                1,
             )
             watcher.onTextChanged(editable, currentEditTextContent.length - 1, 0, 1)
             watcher.afterTextChanged(editable)
@@ -557,7 +560,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentEditTextContent.length,
                 1,
-                currentEditTextContent.length + 1
+                currentEditTextContent.length + 1,
             )
             watcher.onTextChanged(editable, locale.currencySymbol.length + 1, 0, 1)
             watcher.afterTextChanged(editable)
@@ -582,7 +585,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 start,
                 1,
-                currentEditTextContent.length
+                currentEditTextContent.length,
             )
             watcher.onTextChanged(editable, start, 0, 1)
             watcher.afterTextChanged(editable)
@@ -601,7 +604,7 @@ class CurrencyInputWatcherTest {
 
             val (editText, editable, watcher) = setupTestVariables(locale, 0, true)
             `when`(editable.toString()).thenReturn(
-                "${locale.currencySymbol}-1-2${locale.groupingSeparator}255"
+                "${locale.currencySymbol}-1-2${locale.groupingSeparator}255",
             )
 
             val start = expectedCursorPosition + 1 // cursor after -1
@@ -609,7 +612,7 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 start,
                 1,
-                currentEditTextContent.length
+                currentEditTextContent.length,
             )
             watcher.onTextChanged(editable, start, 0, 1)
             watcher.afterTextChanged(editable)
@@ -659,13 +662,13 @@ class CurrencyInputWatcherTest {
 
             val (editText, editable, watcher) = setupTestVariables(locale, 0)
             `when`(editable.toString()).thenReturn(
-                "${locale.currencySymbol}5${locale.decimalSeparator}68"
+                "${locale.currencySymbol}5${locale.decimalSeparator}68",
             )
             watcher.beforeTextChanged(
                 currentEditTextContent,
                 expectedCursorPosition,
                 1,
-                locale.currencySymbol.length + 2
+                locale.currencySymbol.length + 2,
             )
             watcher.onTextChanged(editable, locale.currencySymbol.length + 1, 0, 1)
             watcher.afterTextChanged(editable)
@@ -685,20 +688,20 @@ class CurrencyInputWatcherTest {
 
             val (editText, editable, watcher) = setupTestVariables(locale, 2)
             `when`(editable.toString()).thenReturn(
-                "${locale.currencySymbol}10${locale.decimalSeparator}0"
+                "${locale.currencySymbol}10${locale.decimalSeparator}0",
             )
 
             watcher.beforeTextChanged(
                 currentEditTextContent,
                 currentCursorPosition,
                 1,
-                expectedCursorPosition
+                expectedCursorPosition,
             )
             watcher.onTextChanged(
                 editable,
                 locale.currencySymbol.length + currentCursorPosition,
                 0,
-                1
+                1,
             )
             watcher.afterTextChanged(editable)
 
@@ -723,13 +726,13 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentCursorPosition,
                 1,
-                expectedCursorPosition
+                expectedCursorPosition,
             )
             watcher.onTextChanged(
                 editable,
                 locale.currencySymbol.length + currentCursorPosition,
                 0,
-                1
+                1,
             )
             watcher.afterTextChanged(editable)
 
@@ -746,20 +749,20 @@ class CurrencyInputWatcherTest {
             val currentCursorPosition = locale.currencySymbol.length + 3
             val (editText, editable, watcher) = setupTestVariables(locale, 2)
             `when`(editable.toString()).thenReturn(
-                "${locale.currencySymbol}1${locale.groupingSeparator}0${locale.decimalSeparator}00${locale.decimalSeparator}01"
+                "${locale.currencySymbol}1${locale.groupingSeparator}0${locale.decimalSeparator}00${locale.decimalSeparator}01",
             )
 
             watcher.beforeTextChanged(
                 currentEditTextContent,
                 currentCursorPosition,
                 1,
-                currentCursorPosition
+                currentCursorPosition,
             )
             watcher.onTextChanged(
                 editable,
                 currentCursorPosition,
                 0,
-                1
+                1,
             )
             watcher.afterTextChanged(editable)
 
@@ -774,10 +777,11 @@ class CurrencyInputWatcherTest {
             val currentEditTextContent = "900${locale.decimalSeparator}4"
             val expectedText = "${locale.currencySymbol}900${locale.decimalSeparator}4"
 
-            val (editText, editable, watcher) = setupTestVariables(
-                locale = locale,
-                decimalZerosPadding = false
-            )
+            val (editText, editable, watcher) =
+                setupTestVariables(
+                    locale = locale,
+                    decimalZerosPadding = false,
+                )
             `when`(editable.toString()).thenReturn(currentEditTextContent)
 
             watcher.runAllWatcherMethods(editable)
@@ -793,10 +797,11 @@ class CurrencyInputWatcherTest {
             val currentEditTextContent = "900${locale.decimalSeparator}4"
             val expectedText = "${locale.currencySymbol}900${locale.decimalSeparator}40"
 
-            val (editText, editable, watcher) = setupTestVariables(
-                locale = locale,
-                decimalZerosPadding = true
-            )
+            val (editText, editable, watcher) =
+                setupTestVariables(
+                    locale = locale,
+                    decimalZerosPadding = true,
+                )
             `when`(editable.toString()).thenReturn(currentEditTextContent)
 
             watcher.runAllWatcherMethods(editable)
@@ -812,9 +817,10 @@ class CurrencyInputWatcherTest {
         val currentEditTextContent = "1900${locale.decimalSeparator}4"
         val expectedText = "1900${locale.decimalSeparator}4"
 
-        val (editText, editable, watcher) = setupTestVariables(
-            locale = locale
-        )
+        val (editText, editable, watcher) =
+            setupTestVariables(
+                locale = locale,
+            )
         `when`(editable.toString()).thenReturn(currentEditTextContent)
 
         watcher.runAllWatcherMethods(editable)
@@ -828,9 +834,10 @@ class CurrencyInputWatcherTest {
             val currentEditTextContent = ""
             val expectedText = locale.currencySymbol
 
-            val (editText, editable, watcher) = setupTestVariables(
-                locale = locale
-            )
+            val (editText, editable, watcher) =
+                setupTestVariables(
+                    locale = locale,
+                )
             `when`(editable.toString()).thenReturn(currentEditTextContent)
 
             watcher.runAllWatcherMethods(editable)
@@ -871,13 +878,13 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentCursorPosition,
                 1,
-                expectedCursorPosition
+                expectedCursorPosition,
             )
             watcher.onTextChanged(
                 editable,
                 locale.currencySymbol.length + currentCursorPosition,
                 0,
-                1
+                1,
             )
             watcher.afterTextChanged(editable)
 
@@ -901,13 +908,13 @@ class CurrencyInputWatcherTest {
                 currentEditTextContent,
                 currentCursorPosition,
                 1,
-                expectedCursorPosition
+                expectedCursorPosition,
             )
             watcher.onTextChanged(
                 editable,
                 expectedCursorPosition,
                 0,
-                0
+                0,
             )
             watcher.afterTextChanged(editable)
 
@@ -920,20 +927,21 @@ class CurrencyInputWatcherTest {
         locale: LocaleVars,
         decimalPlaces: Int = 2,
         negativeValueAllow: Boolean = false,
-        decimalZerosPadding: Boolean = false
+        decimalZerosPadding: Boolean = false,
     ): TestVars {
         val editText = mock(CurrencyEditText::class.java)
         val editable = mock(Editable::class.java)
         `when`(editText.text).thenReturn(editable)
         `when`(editable.append(isA(String::class.java))).thenReturn(editable)
-        val watcher = locale.toWatcher(
-            editText,
-            decimalPlaces,
-            locale.decimalSeparator,
-            locale.groupingSeparator,
-            negativeValueAllow,
-            decimalZerosPadding
-        )
+        val watcher =
+            locale.toWatcher(
+                editText,
+                decimalPlaces,
+                locale.decimalSeparator,
+                locale.groupingSeparator,
+                negativeValueAllow,
+                decimalZerosPadding,
+            )
         return TestVars(editText, editable, watcher)
     }
 }
@@ -941,5 +949,5 @@ class CurrencyInputWatcherTest {
 data class TestVars(
     val editText: CurrencyEditText,
     val editable: Editable,
-    val watcher: CurrencyInputWatcher
+    val watcher: CurrencyInputWatcher,
 )

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/CurrencyRounderTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/CurrencyRounderTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,9 +26,8 @@ class CurrencyRounderTest(
     private val current: String,
     private val expected: String,
     private val decimalDigits: Int,
-    private val decimalSeparator: Char
+    private val decimalSeparator: Char,
 ) {
-
     companion object {
         private const val POINT_DECIMAL_SEPARATOR = '.'
         private const val COMMA_DECIMAL_SEPARATOR = ','
@@ -57,41 +56,43 @@ class CurrencyRounderTest(
             arrayOf("515.809", "515.809", THREE, POINT_DECIMAL_SEPARATOR)
         private val noDecimalTestCase = arrayOf("5 809", "5 809", THREE, POINT_DECIMAL_SEPARATOR)
         private val noDecimalTestCase2 = arrayOf("5", "5", THREE, POINT_DECIMAL_SEPARATOR)
-        private val noDecimalTestCase3 = arrayOf(
-            "5,452,635,242,242,423,434,333",
-            "5,452,635,242,242,423,434,333",
-            THREE,
-            POINT_DECIMAL_SEPARATOR
-        )
+        private val noDecimalTestCase3 =
+            arrayOf(
+                "5,452,635,242,242,423,434,333",
+                "5,452,635,242,242,423,434,333",
+                THREE,
+                POINT_DECIMAL_SEPARATOR,
+            )
         private val multipleDecimalTestCase =
             arrayOf("343,432,242,342", "343,432,242,342", TWO, COMMA_DECIMAL_SEPARATOR)
 
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Iterable<Array<out Any>> = listOf(
-            emptyStringTestCase,
-            extraDecimalTestCase1,
-            extraDecimalTestCaseThreeDpVersion,
-            extraDecimalTestCase2,
-            extraDecimalTestCaseWhiteSpaceGrouping,
-            extraDecimalTestCaseCommaDecimal,
-            emptyWholeTestCase,
-            emptyDecimalTestCase,
-            shorterDecimalTestCase,
-            shorterDecimalTestCase2,
-            exactDecimalTestCase,
-            noDecimalTestCase,
-            noDecimalTestCase2,
-            noDecimalTestCase3,
-            multipleDecimalTestCase
-        )
+        fun data(): Iterable<Array<out Any>> =
+            listOf(
+                emptyStringTestCase,
+                extraDecimalTestCase1,
+                extraDecimalTestCaseThreeDpVersion,
+                extraDecimalTestCase2,
+                extraDecimalTestCaseWhiteSpaceGrouping,
+                extraDecimalTestCaseCommaDecimal,
+                emptyWholeTestCase,
+                emptyDecimalTestCase,
+                shorterDecimalTestCase,
+                shorterDecimalTestCase2,
+                exactDecimalTestCase,
+                noDecimalTestCase,
+                noDecimalTestCase2,
+                noDecimalTestCase3,
+                multipleDecimalTestCase,
+            )
     }
 
     @Test
     fun `should return expected value for set of valid inputs`() {
         Assert.assertEquals(
             expected,
-            truncateNumberToMaxDecimalDigits(current, decimalDigits, decimalSeparator)
+            truncateNumberToMaxDecimalDigits(current, decimalDigits, decimalSeparator),
         )
     }
 }

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/Exts.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/Exts.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,18 +18,18 @@ package ru.pravbeseda.currencyedittext
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
-import java.lang.ref.WeakReference
-import java.util.Locale
 import ru.pravbeseda.currencyedittext.model.CurrencyInputWatcherConfig
 import ru.pravbeseda.currencyedittext.model.LocaleVars
 import ru.pravbeseda.currencyedittext.watchers.CurrencyInputWatcher
+import java.lang.ref.WeakReference
+import java.util.Locale
 
 fun TextWatcher.runAllWatcherMethods(
     s: Editable,
     start: Int = 0,
     count: Int = 0,
     before: Int = 0,
-    after: Int = 0
+    after: Int = 0,
 ) {
     beforeTextChanged(s, start, count, after)
     onTextChanged(s, start, before, count)
@@ -50,19 +50,20 @@ fun LocaleVars.toWatcher(
     decimalSeparator: Char? = null,
     groupingSeparator: Char? = null,
     negativeValueAllow: Boolean = false,
-    decimalZerosPadding: Boolean = false
+    decimalZerosPadding: Boolean = false,
 ): CurrencyInputWatcher {
-    val config = CurrencyInputWatcherConfig(
-        currencySymbol = currencySymbol,
-        locale = tag.toLocale(),
-        decimalSeparator = decimalSeparator,
-        groupingSeparator = groupingSeparator,
-        maxNumberOfDecimalPlaces = decimalPlaces,
-        negativeValueAllow = negativeValueAllow,
-        decimalZerosPadding = decimalZerosPadding
-    )
+    val config =
+        CurrencyInputWatcherConfig(
+            currencySymbol = currencySymbol,
+            locale = tag.toLocale(),
+            decimalSeparator = decimalSeparator,
+            groupingSeparator = groupingSeparator,
+            maxNumberOfDecimalPlaces = decimalPlaces,
+            negativeValueAllow = negativeValueAllow,
+            decimalZerosPadding = decimalZerosPadding,
+        )
     return CurrencyInputWatcher(
         WeakReference(editText),
-        config
+        config,
     )
 }

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/Exts.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/Exts.kt
@@ -19,7 +19,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.Locale
 import ru.pravbeseda.currencyedittext.model.CurrencyInputWatcherConfig
 import ru.pravbeseda.currencyedittext.model.LocaleVars
 import ru.pravbeseda.currencyedittext.watchers.CurrencyInputWatcher

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/RoutinesTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/RoutinesTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,146 +15,147 @@
  */
 package ru.pravbeseda.currencyedittext
 
-import java.math.BigDecimal
-import java.util.Locale
 import org.junit.Assert
 import org.junit.Test
 import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
 import ru.pravbeseda.currencyedittext.util.Routines.Companion.bigDecimalToString
+import java.math.BigDecimal
+import java.util.Locale
 
 data class BigDecimalToStringTestCase(
     var bigDecimal: BigDecimal,
     var currencyFormatConfig: CurrencyFormatConfig,
     var result: String,
-    var locale: Locale = Locale.getDefault()
+    var locale: Locale = Locale.getDefault(),
 )
 
 class RoutinesTest {
     @Test
     fun testBigDecimalToString() {
-        val cases = listOf(
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.129456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = '.',
-                    groupingSeparator = ',',
-                    decimalLength = 2
+        val cases =
+            listOf(
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.129456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = '.',
+                        groupingSeparator = ',',
+                        decimalLength = 2,
+                    ),
+                    "123,456,789.12",
                 ),
-                "123,456,789.12"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = '.',
-                    groupingSeparator = ',',
-                    decimalLength = 3
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = '.',
+                        groupingSeparator = ',',
+                        decimalLength = 3,
+                    ),
+                    "123,456,789.123",
                 ),
-                "123,456,789.123"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = '.',
-                    decimalLength = 2
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = '.',
+                        decimalLength = 2,
+                    ),
+                    "123.456.789,12",
                 ),
-                "123.456.789,12"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = '.',
-                    decimalLength = 3
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = '.',
+                        decimalLength = 3,
+                    ),
+                    "123.456.789,123",
                 ),
-                "123.456.789,123"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("-123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 2
+                BigDecimalToStringTestCase(
+                    BigDecimal("-123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 2,
+                    ),
+                    "-123 456 789,13",
                 ),
-                "-123 456 789,13"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 3
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 3,
+                    ),
+                    "123 456 789,123",
                 ),
-                "123 456 789,123"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 0
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 0,
+                    ),
+                    "123 456 789",
                 ),
-                "123 456 789"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 1,
-                    showPlusSign = true
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 1,
+                        showPlusSign = true,
+                    ),
+                    "+123 456 789,1",
                 ),
-                "+123 456 789,1"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 4
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 4,
+                    ),
+                    "123 456 789,1234",
                 ),
-                "123 456 789,1234"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 5
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 5,
+                    ),
+                    "123 456 789,12345",
                 ),
-                "123 456 789,12345"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = ' ',
-                    decimalLength = 6,
-                    showPlusSign = true
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = ' ',
+                        decimalLength = 6,
+                        showPlusSign = true,
+                    ),
+                    "+123 456 789,123456",
                 ),
-                "+123 456 789,123456"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = 'n', // from none
-                    decimalLength = 6,
-                    showPlusSign = true
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = 'n', // from none
+                        decimalLength = 6,
+                        showPlusSign = true,
+                    ),
+                    "+123\u0000456\u0000789,123456",
                 ),
-                "+123\u0000456\u0000789,123456"
-            ),
-            BigDecimalToStringTestCase(
-                BigDecimal("123456789.123456789"),
-                CurrencyFormatConfig(
-                    decimalSeparator = ',',
-                    groupingSeparator = '.',
-                    decimalLength = 3
+                BigDecimalToStringTestCase(
+                    BigDecimal("123456789.123456789"),
+                    CurrencyFormatConfig(
+                        decimalSeparator = ',',
+                        groupingSeparator = '.',
+                        decimalLength = 3,
+                    ),
+                    "123.456.789,123",
+                    Locale.Builder().setLanguage("ar").build(),
                 ),
-                "123.456.789,123",
-                Locale.Builder().setLanguage("ar").build()
             )
-        )
         for (case in cases) {
             Locale.setDefault(case.locale)
             val result = bigDecimalToString(case.bigDecimal, case.currencyFormatConfig)

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/model/LocaleVars.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/model/LocaleVars.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,5 +19,5 @@ data class LocaleVars(
     val tag: String,
     val decimalSeparator: Char,
     val groupingSeparator: Char,
-    val currencySymbol: String
+    val currencySymbol: String,
 )

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,15 +2,18 @@ apply from: '../dependencies.gradle'
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-
 
 android {
+    namespace 'pravbeseda'
     compileSdk 34
 
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8
+    }
+
+    buildFeatures {
+        viewBinding true
     }
 
     defaultConfig {
@@ -22,13 +25,18 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+}
+
 dependencies {
     implementation project(':library')
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10'
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }
 
 apply from: '../spotless.gradle'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="pravbeseda">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
+++ b/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
@@ -18,11 +18,7 @@ package ru.pravbeseda.currencyedittext
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.activity_main.button
-import kotlinx.android.synthetic.main.activity_main.currencyEditText
-import kotlinx.android.synthetic.main.activity_main.currencyMaterialEditText
-import kotlinx.android.synthetic.main.activity_main.textView
-import pravbeseda.R
+import pravbeseda.databinding.ActivityMainBinding
 import ru.pravbeseda.currencyedittext.CurrencyEditText.Companion.State
 import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
 import ru.pravbeseda.currencyedittext.util.Routines.Companion.bigDecimalToString
@@ -30,34 +26,37 @@ import java.math.BigDecimal
 
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityMainBinding
+
     @SuppressLint("SetTextI18n")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        currencyEditText.setValue(BigDecimal(1123.476))
-        currencyMaterialEditText.setValue(BigDecimal(1432.167))
+        binding.currencyEditText.setValue(BigDecimal(1123.476))
+        binding.currencyMaterialEditText.setValue(BigDecimal(1432.167))
 
-        currencyEditText.setDecimalZerosPadding(true)
-        currencyMaterialEditText.setDecimalZerosPadding(true)
-        currencyMaterialEditText.setEmptyStringForZero(false)
+        binding.currencyEditText.setDecimalZerosPadding(true)
+        binding.currencyMaterialEditText.setDecimalZerosPadding(true)
+        binding.currencyMaterialEditText.setEmptyStringForZero(false)
 
-        currencyEditText.onValueChanged { _, state: State, textError: String ->
+        binding.currencyEditText.onValueChanged { _, state: State, textError: String ->
             if (state !== State.ERROR) {
-                textView.text = formatValue(currencyEditText.value)
+                binding.textView.text = formatValue(binding.currencyEditText.value)
             } else {
-                textView.text = textError
+                binding.textView.text = textError
             }
-            currencyMaterialEditText.validate()
+            binding.currencyMaterialEditText.validate()
         }
 
-        textView.text = formatValue(currencyEditText.value)
+        binding.textView.text = formatValue(binding.currencyEditText.value)
 
-        button.setOnClickListener {
-            currencyEditText.text?.clear()
+        binding.button.setOnClickListener {
+            binding.currencyEditText.text?.clear()
         }
 
-        currencyEditText.setValidator { value ->
+        binding.currencyEditText.setValidator { value ->
             var error = ""
             if (value < BigDecimal(1000)) {
                 error = "Value is less than 1000"
@@ -65,9 +64,9 @@ class MainActivity : AppCompatActivity() {
             error
         }
 
-        currencyMaterialEditText.setValidator { value ->
+        binding.currencyMaterialEditText.setValidator { value ->
             var error = ""
-            if (value < currencyEditText.value) {
+            if (value < binding.currencyEditText.value) {
                 error = "Value can't be less than the first field"
             }
             error

--- a/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
+++ b/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ import ru.pravbeseda.currencyedittext.util.Routines.Companion.bigDecimalToString
 import java.math.BigDecimal
 
 class MainActivity : AppCompatActivity() {
-
     private lateinit var binding: ActivityMainBinding
 
     @SuppressLint("SetTextI18n")
@@ -73,15 +72,14 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun formatValue(value: BigDecimal): String {
-        return bigDecimalToString(
+    private fun formatValue(value: BigDecimal): String =
+        bigDecimalToString(
             value,
             CurrencyFormatConfig(
                 decimalSeparator = '.',
                 groupingSeparator = ' ',
                 decimalLength = 2,
-                showPlusSign = true
-            )
+                showPlusSign = true,
+            ),
         )
-    }
 }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,7 +4,6 @@ git stash -q --keep-index
 
 echo "Running git pre-commit hook"
 
-./gradlew :library:spotlessApply
 ./gradlew :library:spotlessCheck
 
 RESULT=$?

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -5,7 +5,7 @@ git stash -q --keep-index
 echo "Running git pre-commit hook"
 
 ./gradlew :library:spotlessApply
-./gradlew ktlint
+./gradlew :library:spotlessCheck
 
 RESULT=$?
 

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,16 +1,11 @@
-apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: "com.diffplug.spotless"
+
 spotless {
-  java {
-    target "**/*.java"
-    trimTrailingWhitespace()
-    removeUnusedImports()
-    googleJavaFormat()
-    endWithNewline()
-  }
   kotlin {
-    target "**/*.kt"
-    ktlint('0.33.0').userData(['indent_size': '4', 'continuation_indent_size': '4'])
-    licenseHeaderFile '../spotless.license.kt'
+    target 'src/**/*.kt'
+    targetExclude '**/build/**'
+    licenseHeaderFile rootProject.file('spotless.license.kt')
+    ktlint('1.8.0')
     trimTrailingWhitespace()
     endWithNewline()
   }

--- a/spotless.license.kt
+++ b/spotless.license.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2022-2023 Alexander Ivanov
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Moves the build off a toolchain that no longer starts on a current JDK, and fixes the
pre-commit hook along the way.

Closes #8.

## Why

Gradle 7.5 refuses to run on JDK 19+ (`Unsupported class file major version`), so on a
machine with only a recent JDK installed nothing in this repository could be built or
tested. Gradle 8.13 needs AGP 8, AGP 8 needs Kotlin 1.9+, and each of those pulls its own
required change — the whole chain is here.

## What changed

| Before | After |
| --- | --- |
| Gradle 7.5 | Gradle 8.13 |
| AGP 7.4.2 | AGP 8.13.0 |
| Kotlin 1.7.21 | Kotlin 2.1.10 |
| Spotless 4.0.0 + ktlint 0.33.0 | Spotless 8.9.0 + ktlint 1.8.0 |
| Mockito 4.7.0 + mockito-inline | Mockito 5.20.0 |
| maven-publish plugin 0.24.0 | 0.34.0 |
| CI on JDK 11 | CI on JDK 17 |

Everything the upgrade forced:

- **`namespace`** — AGP 8 takes the R class package from the build script, not the manifest.
  `library/src/main/AndroidManifest.xml` held nothing but `package=`, so it is deleted; the
  sample keeps its manifest minus that attribute.
- **ViewBinding** — `kotlin-android-extensions` was removed in Kotlin 1.9, so
  `MainActivity` no longer uses synthetic view accessors.
- **ConstraintLayout** — the sample pulled it from the retired
  `com.android.support.constraint` coordinates and relied on Jetifier to rewrite it to
  androidx. It now depends on androidx directly, and `android.enableJetifier` is off.
  Pinned at 2.1.4 because 2.2.x requires minSdk 21 and this project's floor is 19.
- **jvmTarget** — Java source/target stays at 1.8, so both modules pin the Kotlin target to
  match. Without it AGP 8 fails the build on the mismatch.
- **Mockito 5** — 4.7 cannot instrument classes on JDK 17+; 42 of the 58 unit tests died
  with `MockitoException` before this. Mockito 5 makes the inline mock maker the default,
  which is what `mockito-inline` was there for.
- **ktlint 1.x rules** — a KDoc comment is no longer allowed at file top level, so the
  license header is a plain `/*` block; the seven wildcard imports are expanded; and
  `emptyChar` keeps its name under a targeted `@Suppress`, since renaming it to
  `EMPTY_CHAR` would break consumers of the published library.

The reformatting ktlint 1.8 asks for is a **separate second commit**, so the first commit
reads without 500 lines of trailing commas in the way.

## Fix for #8

`scripts/pre-commit` called `./gradlew ktlint` — a task this project has never registered,
since ktlint appears only as a step inside the Spotless configuration. Every commit made
with the hook installed was therefore rejected. It now calls `:library:spotlessCheck`.

## Verification

`./gradlew build` — the exact command CI runs — passes on JDK 21, including `spotlessCheck`
and all 58 unit tests. The instrumented tests under `src/androidTest` were **not** run: they
need a device, and none was available.

## Not in scope

Publishing is broken: `publish.yml` calls Gradle tasks that the new maven-publish plugin no
longer registers, and `SONATYPE_HOST=S01` points at a retired host. Filed as #9, to be fixed
in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1A3KFw9GQ8RGP4eeNnq6j
