### PR TITLE
fix: drop androidx.test:monitor from the library implementation configuration

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
 
     api 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.test:monitor:1.6.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core-ktx:1.5.0'


### PR DESCRIPTION
## Problem

`library/build.gradle` declared `implementation 'androidx.test:monitor:1.6.1'`. It was added in
95d1de7 ("Added CurrencyEditTextTest") together with the instrumented tests, but it landed in the
production configuration.

Consequences:

- `monitor` appears in `releaseVariantReleaseRuntimePublication` of the published Gradle metadata
  (verified in `CurrencyEditText-1.1.0.module`), so it is pulled into every consumer's APK.
- Downstream projects have to work around it with `exclude group: 'androidx.test'`.

## Investigation

No class under `library/src/main` references `androidx.test` in any form
(`grep -rn "androidx.test" library/src/main` → no matches). The only users are the instrumented
tests, which import `androidx.test.platform.app.InstrumentationRegistry`
(`library/src/androidTest/.../CurrencyEditTextTest.kt:19`,
`library/src/androidTest/.../CurrencyMaterialEditTextTest.kt:19`). That class ships in
`androidx.test:monitor`, which `androidx.test:core-ktx`, `androidx.test:runner` and
`androidx.test:rules` already bring in transitively for the `androidTest` source set.

## Change

Removed the single dependency line. Nothing else touched.

## Verification

- `./gradlew :library:assembleRelease` — success.
- `./gradlew :library:generateMetadataFileForMavenPublication :library:generatePomFileForMavenPublication`
  (the publication is named `maven`, so there is no `...ForReleasePublication` task) — success.
- `library/build/publications/maven/module.json` and `pom-default.xml` contain no `androidx.test`
  in any variant. Remaining dependencies:
  - api: `com.google.android.material:material`, `org.jetbrains.kotlin:kotlin-stdlib`
  - runtime: `androidx.appcompat:appcompat`, `com.google.android.material:material`,
    `org.jetbrains.kotlin:kotlin-stdlib`
- `./gradlew :library:test` — success.

## Note

`:library:compileDebugAndroidTestSources` fails with
`CurrencyMaterialEditTextTest.kt:32:28 Unresolved reference 'style'`. This failure is **pre-existing
on `main`** (verified by building the same task on `main` before this change) and is unrelated to
this PR; tracked separately.
