### PR TITLE
fix: make instrumented tests compile and guard them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
           java-version: '17'
 
       - name: Build and Run Tests with Gradle
-        run: ./gradlew build
+        run: ./gradlew build :library:compileDebugAndroidTestSources

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -29,7 +29,7 @@ class CurrencyMaterialEditTextTest {
 
     @Before
     fun init() {
-        context.setTheme(R.style.Theme_AppCompat)
+        context.setTheme(com.google.android.material.R.style.Theme_MaterialComponents_Light)
         currencyEditText = CurrencyMaterialEditText(context, null)
     }
 


### PR DESCRIPTION
Fixes #13

## Problem

`./gradlew :library:compileDebugAndroidTestSources` failed on `main`:

```
e: CurrencyMaterialEditTextTest.kt:32:28 Unresolved reference 'style'.
```

`context.setTheme(R.style.Theme_AppCompat)` resolves `R` to the library's own R class, which — with
non-transitive R classes (the AGP 8 default, in effect since the toolchain upgrade in 23aa8b9) —
contains only this module's resources and has no `style` block at all. The whole instrumented suite
was therefore dead, and `./gradlew build` (what CI runs) never compiles androidTest sources, so the
breakage stayed invisible.

## Changes

- `CurrencyMaterialEditTextTest.kt:32` — use `com.google.android.material.R.style.Theme_MaterialComponents_Light`.
  `material` is an `api` dependency, and `CurrencyMaterialEditText` extends `TextInputLayout`, which
  requires a Material Components theme at runtime; a plain AppCompat theme would only have fixed
  compilation.
- `.github/workflows/ci.yml` — the build step now also runs `:library:compileDebugAndroidTestSources`,
  so a broken instrumented source set fails CI without needing an emulator.

## Verification

- `./gradlew :library:connectedAndroidTest` — 9/9 tests pass on an API 36 emulator.
- `./gradlew build :library:compileDebugAndroidTestSources` (the exact new CI command) — green.
- `./gradlew :library:spotlessCheck` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MHLrtD5cgPVkKGjcgyRi3
