### PR TITLE
chore: freeze the published API with binary-compatibility-validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,16 @@ jobs:
             sample/build/reports/lint-results-debug.*
           if-no-files-found: ignore
 
+      - name: Check binary compatibility
+        # The artifact goes to Maven Central and a release cannot be withdrawn,
+        # so an accidental signature change has to be caught before the merge,
+        # not by the people whose build stops compiling. library/api/library.api
+        # is the dump of the public API; a mismatch prints the diff. An intended
+        # change is made reviewable by running `./gradlew :library:apiDump` and
+        # committing the result.
+        if: always()
+        run: ./gradlew :library:apiCheck --stacktrace
+
       - name: Assemble
         # The instrumented tests are compiled but not run: there is no emulator
         # in this job, and a source set that never compiles is a source set that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ Gradle modules: `:library` (the published artifact) and `:sample` (demo app).
 ./gradlew :library:koverVerifyDebug :library:koverLogDebug  # coverage + the bound
 ./gradlew detektAll                    # detekt with type resolution, both modules
 ./gradlew :library:lintDebug :sample:lintDebug              # Android Lint
+./gradlew :library:apiCheck            # public API against library/api/library.api
+./gradlew :library:apiDump             # rewrite that file after an intended API change
 ```
 
 Toolchain: Gradle 8.13, AGP 8.13.0, Kotlin 2.1.10, JDK 17 (JDK 21 also works), minSdk 19,
@@ -40,7 +42,7 @@ has to be run by hand on a fresh clone.
 
 ## Quality gates
 
-All five block the build, and `./gradlew build` runs all five:
+All six block the build, and `./gradlew build` runs all six:
 
 | Gate | Where it is configured | What is frozen |
 |---|---|---|
@@ -49,6 +51,7 @@ All five block the build, and `./gradlew build` runs all five:
 | Kover 0.9.9, `minBound(80)` | `library/build.gradle` | — the bound is a floor, not a baseline |
 | Android Lint, `warningsAsErrors` | root `build.gradle` | `*/lint-baseline.xml` |
 | Unit tests | `library/src/test` | — |
+| binary-compatibility-validator 0.18.2 | `library/build.gradle` | `library/api/library.api` — the public API, not a debt list |
 
 Coverage is measured on `:library` only and filtered to
 `ru.pravbeseda.currencyedittext.watchers.*` and `…util.*`. The two Views cannot be reached from
@@ -58,6 +61,13 @@ the quality of the tests.
 The plain `detekt` task is disabled on purpose: it analyses without type resolution and would offer
 a green run that checks a fraction of what the gate checks. Use `detektAll`, which is the same list
 of tasks each module's `check` is wired from.
+
+`library/api/library.api` is a dump of the published artifact's public signatures, and `apiCheck`
+is the only gate here that looks at the library's outward boundary rather than at the code inside
+it. It is not a baseline: an intended API change is made by running `./gradlew :library:apiDump`
+and committing the rewritten file, so the change arrives in the diff as a reviewable line instead
+of reaching Maven Central unnoticed — where it cannot be taken back. It is wired into `check`, and
+CI runs it as its own step because that job runs the gate tasks one by one, not `check`.
 
 ## Architecture
 
@@ -141,8 +151,9 @@ class. Reason: `calculateSpacing` is already written that way and the pattern ge
 **No silently swallowed exceptions.** A `catch` that returns a default needs a comment saying why
 losing the information is safe (`util/Utils.kt` `parseMoneyValue` is the example of how not to).
 
-**Public API changes get their own bullet in the PR description**, headed "Public API change".
-Reason: the artifact goes to Maven Central and a release cannot be taken back.
+**Public API changes get their own bullet in the PR description**, headed "Public API change",
+and the `apiDump` diff in the same commit. Reason: the artifact goes to Maven Central and a
+release cannot be taken back.
 
 **Test libraries belong in `testImplementation` / `androidTestImplementation`, never in
 `implementation`.** Reason: this repository has already shipped that bug — `androidx.test:monitor`

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ plugins {
     // Applied in :library only — see library/build.gradle for why the sample app
     // is left out.
     alias(libs.plugins.kover) apply false
+    // Also :library only: what it records is the published artifact's public
+    // API, and :sample publishes nothing.
+    alias(libs.plugins.binary.compatibility.validator) apply false
     // detekt 1.23.8 is the last stable line: detekt 2.x has been in alpha since
     // 2025 and wants Gradle 8.14.3+, while this project builds on 8.13. It is
     // compiled against Kotlin 2.0.21, so it prints a version-mismatch warning on

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@ kotlin = "2.1.10"
 mavenPublish = "0.34.0"
 
 # --- quality gates ---------------------------------------------------------
+# The standalone plugin rather than the Kotlin Gradle Plugin's own
+# `abiValidation {}`: the built-in one is where this is heading, but its DSL is
+# experimental and needs Kotlin 2.2+, and this project is on 2.1.10.
+binaryCompatibilityValidator = "0.18.2"
 # 1.23.8 is the last stable line; detekt 2.x has been in alpha since 2025 and
 # requires Gradle 8.14.3+, while this project builds on 8.13. See the note in the
 # root build script for why its Kotlin version-mismatch warning is tolerated.
@@ -51,6 +55,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1,0 +1,157 @@
+public class ru/pravbeseda/currencyedittext/CurrencyEditText : androidx/appcompat/widget/AppCompatEditText {
+	public static final field Companion Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion;
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public final fun getDecimalSeparator ()C
+	public final fun getDecimalZerosPadding ()Z
+	public final fun getEmptyStringForZero ()Z
+	public final fun getGroupingSeparator ()C
+	public final fun getNegativeValueAllow ()Z
+	public final fun getValue ()Ljava/math/BigDecimal;
+	public final fun getValue0 ()Ljava/math/BigDecimal;
+	public final fun isValid ()Z
+	public final fun isValidState ()Z
+	protected fun onFocusChanged (ZILandroid/graphics/Rect;)V
+	protected fun onSelectionChanged (II)V
+	public final fun onValueChanged (Lkotlin/jvm/functions/Function3;)V
+	public final fun setCurrencySymbol (Ljava/lang/String;Z)V
+	public static synthetic fun setCurrencySymbol$default (Lru/pravbeseda/currencyedittext/CurrencyEditText;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun setDecimalZerosPadding (Z)V
+	public final fun setEmptyStringForZero (Z)V
+	public final fun setLocale (Ljava/lang/String;)V
+	public final fun setLocale (Ljava/util/Locale;)V
+	public final fun setMaxNumberOfDecimalPlaces (I)V
+	public final fun setNegativeValueAllow (Z)V
+	public final fun setSeparators (CC)V
+	public fun setText (Ljava/lang/CharSequence;Landroid/widget/TextView$BufferType;)V
+	public final fun setValidator (Lkotlin/jvm/functions/Function1;)V
+	public final fun setValue (Ljava/math/BigDecimal;)V
+	public final fun setValue0 (Ljava/math/BigDecimal;)V
+	public final fun validate (Ljava/math/BigDecimal;)V
+	public static synthetic fun validate$default (Lru/pravbeseda/currencyedittext/CurrencyEditText;Ljava/math/BigDecimal;ILjava/lang/Object;)V
+}
+
+public final class ru/pravbeseda/currencyedittext/CurrencyEditText$Companion {
+}
+
+public final class ru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State : java/lang/Enum {
+	public static final field ERROR Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State;
+	public static final field OK Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State;
+	public static fun values ()[Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State;
+}
+
+public abstract interface class ru/pravbeseda/currencyedittext/CurrencyEditText$OnValueChanged {
+	public abstract fun onValueChanged (Ljava/math/BigDecimal;Lru/pravbeseda/currencyedittext/CurrencyEditText$Companion$State;Ljava/lang/String;)V
+}
+
+public class ru/pravbeseda/currencyedittext/CurrencyMaterialEditText : com/google/android/material/textfield/TextInputLayout {
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public final fun getDecimalZerosPadding ()Z
+	public final fun getEmptyStringForZero ()Z
+	public final fun getNegativeValueAllow ()Z
+	public final fun getText ()Landroid/text/Editable;
+	public final fun getValue ()Ljava/math/BigDecimal;
+	public final fun getValue0 ()Ljava/math/BigDecimal;
+	public final fun isValid ()Z
+	public final fun isValidState ()Z
+	public final fun onValueChanged (Lkotlin/jvm/functions/Function3;)V
+	public final fun setDecimalZerosPadding (Z)V
+	public final fun setEmptyStringForZero (Z)V
+	public final fun setLocale (Ljava/lang/String;)V
+	public final fun setLocale (Ljava/util/Locale;)V
+	public final fun setMaxNumberOfDecimalPlaces (I)V
+	public final fun setNegativeValueAllow (Z)V
+	public final fun setSelectAllOnFocus (Z)V
+	public final fun setSeparators (CC)V
+	public final fun setText (Landroid/text/Editable;)V
+	public final fun setText (Ljava/lang/CharSequence;)V
+	public final fun setValidator (Lkotlin/jvm/functions/Function1;)V
+	public final fun setValue (Ljava/math/BigDecimal;)V
+	public final fun setValue0 (Ljava/math/BigDecimal;)V
+	public final fun validate ()V
+}
+
+public final class ru/pravbeseda/currencyedittext/model/CurrencyFormatConfig {
+	public fun <init> ()V
+	public fun <init> (CCIZZ)V
+	public synthetic fun <init> (CCIZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()C
+	public final fun component2 ()C
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (CCIZZ)Lru/pravbeseda/currencyedittext/model/CurrencyFormatConfig;
+	public static synthetic fun copy$default (Lru/pravbeseda/currencyedittext/model/CurrencyFormatConfig;CCIZZILjava/lang/Object;)Lru/pravbeseda/currencyedittext/model/CurrencyFormatConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddLTRPrefix ()Z
+	public final fun getDecimalLength ()I
+	public final fun getDecimalSeparator ()C
+	public final fun getGroupingSeparator ()C
+	public final fun getShowPlusSign ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Locale;Ljava/lang/String;Ljava/lang/Character;Ljava/lang/Character;IZZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/util/Locale;Ljava/lang/String;Ljava/lang/Character;Ljava/lang/Character;IZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Locale;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Character;
+	public final fun component4 ()Ljava/lang/Character;
+	public final fun component5 ()I
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/util/Locale;Ljava/lang/String;Ljava/lang/Character;Ljava/lang/Character;IZZLkotlin/jvm/functions/Function1;)Lru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig;
+	public static synthetic fun copy$default (Lru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig;Ljava/util/Locale;Ljava/lang/String;Ljava/lang/Character;Ljava/lang/Character;IZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrencySymbol ()Ljava/lang/String;
+	public final fun getDecimalSeparator ()Ljava/lang/Character;
+	public final fun getDecimalZerosPadding ()Z
+	public final fun getGroupingSeparator ()Ljava/lang/Character;
+	public final fun getLocale ()Ljava/util/Locale;
+	public final fun getMaxNumberOfDecimalPlaces ()I
+	public final fun getNegativeValueAllow ()Z
+	public final fun getOnValueChanged ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ru/pravbeseda/currencyedittext/util/CurrencyRounderKt {
+	public static final fun truncateNumberToMaxDecimalDigits (Ljava/lang/String;IC)Ljava/lang/String;
+}
+
+public final class ru/pravbeseda/currencyedittext/util/Routines {
+	public static final field Companion Lru/pravbeseda/currencyedittext/util/Routines$Companion;
+	public fun <init> ()V
+}
+
+public final class ru/pravbeseda/currencyedittext/util/Routines$Companion {
+	public final fun bigDecimalToString (Ljava/math/BigDecimal;Lru/pravbeseda/currencyedittext/model/CurrencyFormatConfig;)Ljava/lang/String;
+}
+
+public final class ru/pravbeseda/currencyedittext/util/RoutinesKt {
+	public static final field emptyChar C
+	public static final fun firstChar (Ljava/lang/String;)Ljava/lang/Character;
+}
+
+public final class ru/pravbeseda/currencyedittext/watchers/CurrencyInputWatcher : ru/pravbeseda/currencyedittext/watchers/EasyTextWatcher {
+	public fun <init> (Ljava/lang/ref/WeakReference;Lru/pravbeseda/currencyedittext/model/CurrencyInputWatcherConfig;)V
+	public final fun getDecimalSeparator ()C
+	public final fun getGroupingSeparator ()C
+	public fun onTextModified (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+}
+
+public abstract class ru/pravbeseda/currencyedittext/watchers/EasyTextWatcher : android/text/TextWatcher {
+	public fun <init> ()V
+	public fun afterTextChanged (Landroid/text/Editable;)V
+	public fun beforeTextChanged (Ljava/lang/CharSequence;III)V
+	public fun endEditing ()V
+	public fun onTextChanged (Ljava/lang/CharSequence;III)V
+	public abstract fun onTextModified (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public fun startEditing ()V
+}
+

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.kover)
+    alias(libs.plugins.binary.compatibility.validator)
 }
 
 android {


### PR DESCRIPTION
## Why

The library publishes to Maven Central, where a release cannot be withdrawn, and nothing today
catches an accidental signature change. Every existing gate — Spotless, detekt, Kover, Lint, unit
tests — looks inside the code; none looks at its outward boundary, so a renamed public method or a
changed return type reaches users as a build that stops compiling.

Part 3 of #18. Parts 1 (instrumented tests on an emulator in CI) and 2 (`dependency-analysis` as a
periodic `buildHealth` audit) are untouched and the issue stays open.

## What changed

- `binary-compatibility-validator` 0.18.2 applied to `:library` only — `:sample` publishes nothing.
- `library/api/library.api` — the dump of the public API, 157 lines: both Views,
  `CurrencyFormatConfig`, `CurrencyInputWatcherConfig`, `Routines`, `CurrencyInputWatcher`,
  `EasyTextWatcher`.
- A `Check binary compatibility` step in `ci.yml`. `apiCheck` is wired into `check`, so
  `./gradlew build` and the release workflow already run it; the CI job runs the gate tasks one by
  one rather than `check`, so it needs the step spelled out.
- `CLAUDE.md`: the gates table goes from five to six, the command list gains `apiCheck` / `apiDump`,
  and the "Public API change" rule now also asks for the `apiDump` diff in the same commit.

## How an intended API change works from now on

`./gradlew :library:apiDump`, then commit the rewritten `library/api/library.api`. It is not a
baseline of accepted debt: the file is meant to change, and the point is that the change shows up
in the diff as a reviewable line instead of being noticed after publication.

## Plugin choice

The standalone plugin rather than the Kotlin Gradle Plugin's own `abiValidation {}`. The built-in
one is the direction upstream is going, but its DSL is experimental and needs Kotlin 2.2+, while
this project is on 2.1.10. The reason is recorded next to the version in `libs.versions.toml`, so
the decision is not rediscovered when the toolchain moves.

## Public API change

None. The dump was generated from the current sources and no signature was touched.

## Testing

- `./gradlew build` — green.
- The gate was watched failing first: a temporary `fun temporaryAbiProbe(): String` added to
  `util/Routines.kt` made `:library:apiCheck` fail and print the diff of the added line; the probe
  was then removed.
- No unit tests, because the change is entirely build scripts, CI configuration and a generated
  dump — there is no `library/src/main` logic to cover.
