### PR TITLE
Update the GitHub Actions off Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        # Held at v5 on purpose: v6 moved the caching this step relies on into
+        # gradle-actions-caching, a proprietary component under Gradle's own
+        # Terms of Use rather than the MIT licence. v5 is the last release that
+        # runs on Node 24 without that decision attached.
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Check formatting
         # First, and blocking: ktlint is deterministic, needs no Android SDK and
@@ -49,7 +53,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-report
           path: library/build/reports/tests
@@ -72,7 +76,7 @@ jobs:
 
       - name: Upload detekt report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: detekt-report
           path: |
@@ -89,7 +93,7 @@ jobs:
 
       - name: Upload lint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lint-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Full history: the push below rebases the bump commit onto main.
           fetch-depth: 0
 
       - name: Install JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
Every CI run currently ends with a deprecation annotation: `actions/checkout@v4`, `actions/setup-java@v4`, `actions/upload-artifact@v4` and `gradle/actions/setup-gradle@v4` target Node 20 and are already being forced onto Node 24 by the runner.

## What changed

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-java` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `gradle/actions/setup-gradle` | v4 | v5 |

None of the inputs this repository passes — `distribution`, `java-version`, `name`, `path`, `if-no-files-found`, `fetch-depth` — changed across those majors. The new majors are Node 24 releases and need runner 2.327.1 or newer, which the GitHub-hosted `ubuntu-latest` images are well past.

## Why setup-gradle stops at v5

`gradle/actions@v6` extracted the caching this step relies on into `gradle-actions-caching`, a proprietary component that is no longer MIT-licensed: using it means accepting [Gradle's Terms of Use](https://gradle.com/legal/terms-of-use/). v5 is the last release that runs on Node 24 with the caching still under the MIT licence, so it clears the deprecation without attaching a licensing decision to it. The reason is in a comment above the step, and moving to v6 can be decided on its own merits later.

## Verification

The workflow file cannot be checked locally beyond YAML validity — this PR's own `ci` run is the test, and it exercises every changed action: checkout, setup-java, setup-gradle and all three artifact uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MHLrtD5cgPVkKGjcgyRi3
