### PR TITLE
chore: move ABI validation into the Kotlin plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,10 @@ jobs:
         # so an accidental signature change has to be caught before the merge,
         # not by the people whose build stops compiling. library/api/library.api
         # is the dump of the public API; a mismatch prints the diff. An intended
-        # change is made reviewable by running `./gradlew :library:apiDump` and
-        # committing the result.
+        # change is made reviewable by running `./gradlew :library:updateKotlinAbi`
+        # and committing the result.
         if: always()
-        run: ./gradlew :library:apiCheck --stacktrace
+        run: ./gradlew :library:checkKotlinAbi --stacktrace
 
       - name: Assemble
         # The instrumented tests are compiled but not run: there is no emulator

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ Gradle modules: `:library` (the published artifact) and `:sample` (demo app).
 ./gradlew :library:koverVerifyDebug :library:koverLogDebug  # coverage + the bound
 ./gradlew detektAll                    # detekt with type resolution, both modules
 ./gradlew :library:lintDebug :sample:lintDebug              # Android Lint
-./gradlew :library:apiCheck            # public API against library/api/library.api
-./gradlew :library:apiDump             # rewrite that file after an intended API change
+./gradlew :library:checkKotlinAbi      # public API against library/api/library.api
+./gradlew :library:updateKotlinAbi     # rewrite that file after an intended API change
 ```
 
 Toolchain: Gradle 8.14.5, AGP 8.13.0, Kotlin 2.4.10, JDK 17 (JDK 21 also works), minSdk 19,
@@ -51,7 +51,7 @@ All six block the build, and `./gradlew build` runs all six:
 | Kover 0.9.9, `minBound(80)` | `library/build.gradle` | — the bound is a floor, not a baseline |
 | Android Lint, `warningsAsErrors` | root `build.gradle` | `*/lint-baseline.xml` |
 | Unit tests | `library/src/test` | — |
-| binary-compatibility-validator 0.18.2 | `library/build.gradle` | `library/api/library.api` — the public API, not a debt list |
+| ABI validation (Kotlin plugin's `abiValidation {}`) | `library/build.gradle` | `library/api/library.api` — the public API, not a debt list |
 
 Coverage is measured on `:library` only and filtered to
 `ru.pravbeseda.currencyedittext.watchers.*` and `…util.*`. The two Views cannot be reached from
@@ -62,12 +62,18 @@ The plain `detekt` task is disabled on purpose: it analyses without type resolut
 a green run that checks a fraction of what the gate checks. Use `detektAll`, which is the same list
 of tasks each module's `check` is wired from.
 
-`library/api/library.api` is a dump of the published artifact's public signatures, and `apiCheck`
-is the only gate here that looks at the library's outward boundary rather than at the code inside
-it. It is not a baseline: an intended API change is made by running `./gradlew :library:apiDump`
-and committing the rewritten file, so the change arrives in the diff as a reviewable line instead
-of reaching Maven Central unnoticed — where it cannot be taken back. It is wired into `check`, and
-CI runs it as its own step because that job runs the gate tasks one by one, not `check`.
+`library/api/library.api` is a dump of the published artifact's public signatures, and
+`checkKotlinAbi` is the only gate here that looks at the library's outward boundary rather than at
+the code inside it. It is not a baseline: an intended API change is made by running
+`./gradlew :library:updateKotlinAbi` and committing the rewritten file, so the change arrives in
+the diff as a reviewable line instead of reaching Maven Central unnoticed — where it cannot be
+taken back. The Kotlin Gradle Plugin wires it into `check` itself, and CI runs it as its own step
+because that job runs the gate tasks one by one, not `check`.
+
+The gate is the Kotlin plugin's own `abiValidation {}`, enabled in `library/build.gradle`, rather
+than the standalone `binary-compatibility-validator` plugin it replaced in #21. Same reference
+file, byte for byte: the swap changed no line of the dump. `checkLegacyAbi` and `updateLegacyAbi`
+exist as aliases of the two tasks above — do not use them, they are the deprecated spelling.
 
 ## Architecture
 
@@ -159,7 +165,7 @@ class, the way every step of the formatter returns a `TextWithCursor`.
 losing the information is safe (`util/Utils.kt` `parseMoneyValue` is the example of how not to).
 
 **Public API changes get their own bullet in the PR description**, headed "Public API change",
-and the `apiDump` diff in the same commit. Reason: the artifact goes to Maven Central and a
+and the `updateKotlinAbi` diff in the same commit. Reason: the artifact goes to Maven Central and a
 release cannot be taken back.
 
 **Test libraries belong in `testImplementation` / `androidTestImplementation`, never in

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ plugins {
     // Applied in :library only — see library/build.gradle for why the sample app
     // is left out.
     alias(libs.plugins.kover) apply false
-    // Also :library only: what it records is the published artifact's public
-    // API, and :sample publishes nothing.
-    alias(libs.plugins.binary.compatibility.validator) apply false
     // detekt 1.23.8 is the last stable line: detekt 2.x has been in alpha since
     // 2025, and an alpha is not what a build gate is made of. It is compiled
     // against Kotlin 2.0.21, four minor lines behind our 2.4.10, so the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,11 +12,6 @@ kotlin = "2.4.10"
 mavenPublish = "0.34.0"
 
 # --- quality gates ---------------------------------------------------------
-# The standalone plugin rather than the Kotlin Gradle Plugin's own
-# `abiValidation {}`. Kotlin is now new enough for the built-in one, so this
-# entry is on its way out: issue #21 replaces it in its own change, where the
-# dump's format diff can be reviewed on its own.
-binaryCompatibilityValidator = "0.18.2"
 # 1.23.8 is the last stable line; detekt 2.x has been in alpha since 2025. See
 # the note in the root build script for how its lag behind our Kotlin version is
 # checked rather than tolerated.
@@ -56,7 +51,6 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.kover)
-    alias(libs.plugins.binary.compatibility.validator)
 }
 
 android {
@@ -37,6 +36,16 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+
+    // The public API gate, and the only one here that looks at the artifact's
+    // outward boundary. It is the Kotlin plugin's own feature rather than the
+    // standalone binary-compatibility-validator it replaced in #21: same
+    // reference file and, byte for byte, the same dump, with one dependency
+    // fewer. `checkKotlinAbi` is wired into `check` by the plugin; an intended
+    // change is committed by running `updateKotlinAbi`.
+    abiValidation {
+        enabled = true
     }
 }
 


### PR DESCRIPTION
Second and last change of issue #21. The first raised Kotlin to 2.4.10 (#29);
this one spends that on what the upgrade was for.

The standalone `binary-compatibility-validator` was chosen in #20 only because
the Kotlin Gradle Plugin's own `abiValidation {}` needs Kotlin 2.2+, which the
project did not have. It has it now, so the gate moves to where the toolchain
does the job itself. Closes #21.

## What changed

- `library/build.gradle`: `abiValidation { enabled = true }` inside the existing
  `kotlin {}` block, with a comment saying what the gate is for.
- The standalone plugin is gone from three places: the `plugins` block of
  `:library`, the `apply false` line in the root `build.gradle`, and both the
  version and the plugin alias in `gradle/libs.versions.toml`.
- `.github/workflows/ci.yml`: the `Check binary compatibility` step now runs
  `:library:checkKotlinAbi`.
- `CLAUDE.md`: the two commands, the gates table row, the `library/api/library.api`
  paragraph and the "Public API changes" rule.

## Public API change

None, and this is the change where that had to be proven rather than assumed.
`library/api/library.api` **is untouched in this diff**: the built-in tool writes
the same reference file, and its output is byte-identical to what the standalone
plugin produced. It was checked directly rather than by eye — a line appended to
the reference file was written back out by `updateKotlinAbi`, and the result
`diff`s clean against a copy taken before the swap. Issue #21 asked for a diff
that is a format change only, with no signature appearing or disappearing; there
is no diff at all.

## What the tasks are actually called

Checked by running the plugin, not from memory:

- `:library:checkKotlinAbi` — the gate. The Kotlin Gradle Plugin wires it into
  `check` itself, so nothing had to be wired by hand; only CI, which runs the
  gate tasks one by one, needed the rename.
- `:library:updateKotlinAbi` — rewrites the reference dump.
- `checkLegacyAbi` / `updateLegacyAbi` exist as deprecated aliases of those two.
  `CLAUDE.md` says not to use them.

## The gate was watched failing

The same way #20 was verified. A public method added to `CurrencyEditText`:

```
> Task :library:checkKotlinAbi FAILED
  <<<ABI has changed>>>
  --- library/api/library.api
  +++ library/build/kotlin/abi/library.api
  +	public final fun abiGateProbe ()I
  You can run ':library:updateKotlinAbi' task to create or overwrite reference ABI declarations
```

The probe was then removed and the gate is green again.

## Verification

`./gradlew clean build` — BUILD SUCCESSFUL, 241 tasks executed, all six gates ran.
Filtered line coverage 85.6% against the `minBound(80)` floor.

## Tests

No new tests: the change is build scripts and documentation only, which
`CLAUDE.md` exempts. The behaviour that had to be verified is the gate itself,
and it was, by watching it fail.
