### PR TITLE
fix: pin the separators in shouldSetDecimalZerosPadding

### DIFF
--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -72,6 +72,9 @@ class CurrencyMaterialEditTextTest {
 
     @Test
     fun shouldSetDecimalZerosPadding() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            currencyEditText.setSeparators(' ', '.')
+        }
         currencyEditText.setDecimalZerosPadding(true)
         testSetText("100.1", "100.10")
         currencyEditText.setDecimalZerosPadding(false)


### PR DESCRIPTION
Closes #31.

`CurrencyMaterialEditTextTest.shouldSetDecimalZerosPadding` asserted on `"100.10"` without pinning
the separators, so it inherited them from the device's default locale. On a ru-RU device `"100.1"`
was read with `.` as a grouping separator and the field showed `1 001`. It was the only test in
either instrumented class asserting on a string with a separator without setting one first.

The fix is the three lines the issue prescribes: `setSeparators(' ', '.')` on the main thread,
the way `shouldSetText` already does it.

## Verification

The emulator here is a production image, so `persist.sys.locale` cannot be set. Instead a throwaway
instrumented test pinned `Locale("ru", "RU")` explicitly and reproduced the issue's exact failure:

```
org.junit.ComparisonFailure: expected:<1[00.10]> but was:<1[ 001]>
```

The same test with `setSeparators(' ', '.')` passed. The scratch file was then deleted, and the real
suite runs green: `OK (9 tests)` on API 36, plus `./gradlew build` locally.

No production code changed, so no new unit test — this is a fix to a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKQTpTPQT9XphP1WAX8zV4
