### PR TITLE
docs: state why an unparseable field reads as zero (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ edittext.setValue(BigDecimal(4321.76))
 val value = edittext.getValue()
 ```
 
+`getValue` always returns a number: an empty field reads as `BigDecimal.ZERO`.
+
 Or you can set the text value directly:
 
 ```Kotlin

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -101,6 +101,12 @@ class CurrencyEditTextTest {
         assertEquals("1,000.45", currencyEditText.text.toString())
     }
 
+    @Test
+    fun `Issue #23 - an empty field reads as zero`() {
+        setText("")
+        assertEquals(BigDecimal.ZERO, currencyEditText.getValue())
+    }
+
     private fun setValue(value: BigDecimal) {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             currencyEditText.setValue(value)

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
@@ -121,6 +121,7 @@ open class CurrencyEditText(
         )
     }
 
+    /** The number in the field. A field holding no number — an empty one — reads as zero. */
     fun getValue(): BigDecimal = stringToBigDecimal(text.toString())
 
     fun setLocale(locale: Locale) {

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
@@ -114,6 +114,7 @@ open class CurrencyMaterialEditText(
         editText.setValue(value)
     }
 
+    /** The number in the field. A field holding no number — an empty one — reads as zero. */
     fun getValue(): BigDecimal = editText.getValue()
 
     fun setText(text: CharSequence) {

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/Utils.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/Utils.kt
@@ -46,6 +46,9 @@ internal fun parseMoneyValueWithLocale(
     return try {
         NumberFormat.getInstance(Locale.ENGLISH).parse(valueWithoutSeparator)!!
     } catch (exception: ParseException) {
+        // Whatever reaches here holds no number at all — an empty or half-typed field, such as
+        // a lone minus sign — and zero is what such a field is worth. Nothing is lost: getValue()
+        // states that a field holding no number reads as zero.
         0
     }
 }

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/util/UtilsTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/util/UtilsTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UtilsTest {
+    @Test
+    fun `Issue #23 - a field holding no number reads as zero`() {
+        listOf("", " ", "$ ", "-", "abc").forEach { value ->
+            assertEquals(
+                "\"$value\" should read as zero",
+                0,
+                parseMoneyValueWithLocale(value, ',', '.', "$ ").toInt(),
+            )
+        }
+    }
+
+    @Test
+    fun `a field holding a number reads as that number`() {
+        assertEquals(1234.56, parseMoneyValueWithLocale("$ 1,234.56", ',', '.', "$ ").toDouble(), 0.0)
+    }
+}


### PR DESCRIPTION
Closes #23.

`parseMoneyValueWithLocale` (`library/src/main/java/ru/pravbeseda/currencyedittext/util/Utils.kt:49`)
caught `ParseException` and returned `0` with nothing saying why — the case CLAUDE.md names as the
example of how not to handle a failure.

Option 1 of the three the issue listed was chosen: the value is right, so what was missing is the
reason, not a new contract. Whatever reaches that `catch` holds no number at all — an empty or
half-typed field, such as a lone minus sign — and zero is what such a field is worth. Returning
`null` from `getValue()` would break every consumer for a case that is not an error, and belongs in
a major release if it is ever wanted.

## What changed

- a comment at the `catch` saying why losing the exception is safe;
- KDoc on `CurrencyEditText.getValue()` and `CurrencyMaterialEditText.getValue()` stating the
  contract: a field holding no number reads as zero;
- `library/src/test/.../util/UtilsTest.kt` — pins `""`, `" "`, `"$ "`, `"-"`, `"abc"` as zero, and a
  real value as itself;
- `CurrencyEditTextTest` — `Issue #23 - an empty field reads as zero`, pinning `getValue()` on an
  empty view, which nothing covered before;
- README — one line: `getValue` always returns a number, an empty field reads as `BigDecimal.ZERO`.

No public API change: `library/api/library.api` is untouched, `checkKotlinAbi` is green.

## Tests

The implementation here is a comment and KDoc — behaviour does not change — so the new tests were
green on their first run rather than red → green. They are characterisation tests: they pin a
contract that nothing held down before, so a future change to that `catch` fails the build.

`./gradlew build detektAll` passes locally. The instrumented test runs on the API 24 emulator on
push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKQTpTPQT9XphP1WAX8zV4
