### PR TITLE
refactor!: hide firstChar from the published API

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -131,7 +131,6 @@ public final class ru/pravbeseda/currencyedittext/util/Routines$Companion {
 
 public final class ru/pravbeseda/currencyedittext/util/RoutinesKt {
 	public static final field emptyChar C
-	public static final fun firstChar (Ljava/lang/String;)Ljava/lang/Character;
 }
 
 public final class ru/pravbeseda/currencyedittext/watchers/CurrencyInputWatcher : ru/pravbeseda/currencyedittext/watchers/EasyTextWatcher {

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt
@@ -54,4 +54,4 @@ class Routines {
     }
 }
 
-fun String?.firstChar(): Char? = if (!this.isNullOrEmpty()) this[0] else null
+internal fun String?.firstChar(): Char? = if (!this.isNullOrEmpty()) this[0] else null


### PR DESCRIPTION
Closes #22.

## What

`String?.firstChar()` (`library/src/main/java/ru/pravbeseda/currencyedittext/util/Routines.kt:57`)
is now `internal`. It is a one-line convenience for reading the first character of an XML attribute,
called only from the `init` blocks of the two Views (`CurrencyEditText.kt:84,86`,
`CurrencyMaterialEditText.kt:74,76`). Nothing in `:sample` uses it. It was public only because
nobody had said otherwise — unlike `emptyChar` three lines above it, which carries a comment
recording that its name is deliberate.

The issue's other half was already done: `truncateNumberToMaxDecimalDigits` was removed in 295fea1,
which is on `main` and not yet released.

## Public API change

`library/api/library.api` loses exactly one line:

```
-	public static final fun firstChar (Ljava/lang/String;)Ljava/lang/Character;
```

Regenerated with `./gradlew :library:updateKotlinAbi` (the issue names `apiDump`, the spelling from
the binary-compatibility-validator plugin that #21 replaced).

This narrows the surface published to Maven Central, so the removal is source- and
binary-incompatible for anyone who called it. Together with the already-merged removal of
`truncateNumberToMaxDecimalDigits` it goes out under the increment #24 already recorded for that
one: **the next release is 2.0.0**, not a patch and not a minor.

## Tests

No tests, because this changes visibility and not behaviour: the four call sites are unchanged and
live in the same module. The ABI dump diff is the verification.

## Checks

`./gradlew build` green locally — all six gates, `checkKotlinAbi` included.
