### PR TITLE
feat: calculator core — expression evaluator and key state machine

### DIFF
--- a/.github/tasks/calculator-input-panel.md
+++ b/.github/tasks/calculator-input-panel.md
@@ -1,0 +1,139 @@
+# Optional calculator panel for CurrencyEditText and CurrencyMaterialEditText
+
+An opt-in calculator, opened from a button at the right edge of the field, that evaluates an
+arithmetic expression and writes the result back into the field. One key toggles the sign of the
+current operand.
+
+## Survey of ready-made options (2026-09-07)
+
+Nothing off the shelf fits, so the panel and the evaluator are written here:
+
+- [CalculatorInputView](https://github.com/Gperez88/CalculatorInputView) — Java, marked *retired*,
+  last change 2018.
+- [number-keyboard](https://github.com/davidmigloz/number-keyboard) 5.0.2 — alive, Apache-2.0, but
+  Compose-only since 4.0.0; the View version is frozen at v3. `:library` has no Compose dependency
+  and should not gain one.
+- [Android-CustomKeyboard](https://github.com/DonBrody/Android-CustomKeyboard) — unmaintained.
+- [mXparser](https://mathparser.org/) 6.1.1 — alive, but dual-licensed: commercial apps must buy a
+  licence. Unacceptable for an artifact published to Maven Central.
+- [exp4j](https://github.com/fasseg/exp4j) — Apache-2.0, ~50 KB, no dependencies, but evaluates in
+  `double` and is not in active development. This project handles money in `BigDecimal`.
+
+## Decisions
+
+1. Own View-based panel, own expression evaluator on `BigDecimal`. No new dependency.
+2. The panel is a `PopupWindow` anchored under the field. The system keyboard is not replaced —
+   `showSoftInputOnFocus` stays untouched, so existing input behaviour is unchanged.
+3. Full expression with operator precedence and parentheses. Keys: `0`–`9`, decimal separator,
+   `+ − × ÷`, `( )`, `±`, `⌫`, `C`, `=`. No percent, no memory, no history.
+4. Division uses `MathContext(16, HALF_UP)` inside the expression; the value written back on `=`
+   is rounded to the field's `maxNumberOfDecimalPlaces`, `HALF_UP`.
+5. `±` flips the sign of the operand currently being entered, and never writes a double sign: a
+   binary `+` or `-` in front of that operand is flipped instead, so `100-50` becomes `100+50`.
+   Only `*` and `/`, which cannot absorb a sign, get a unary minus written after them. When
+   `negativeValueAllow` is false the key is disabled (visible but greyed), so the panel layout
+   does not shift between fields.
+6. Opt-in through a new XML attribute `calculatorEnabled`, default `false`, plus
+   `setCalculatorEnabled` / `isCalculatorEnabled` on both views. Ships in the existing artifact.
+
+## Assumptions (routine calls, change if wrong)
+
+- The panel opens seeded with the field's current value as the first operand.
+- `=` writes through the view's existing `setValue(BigDecimal)`, so grouping, currency prefix and
+  padding all come from `CurrencyInputWatcher` as usual, then closes the popup.
+- Division by zero, an incomplete expression, or a negative result in a field with
+  `negativeValueAllow = false`: the panel shows an error state and writes nothing. No exception
+  escapes to the host app.
+- The panel renders digits and the decimal key using the field's own resolved separators.
+- The popup closes on outside tap and on back press, leaving the field unchanged.
+- Panel layout and drawables stay private resources (`res/`, not `res-public/`).
+
+## Non-goals
+
+- Replacing the system keyboard (that could be added later as a second display mode without
+  breaking this API).
+- Scientific functions, percent, memory keys, expression history.
+- Exposing the evaluator or a `MathContext` as public API.
+
+## Architecture
+
+New package `ru.pravbeseda.currencyedittext.calculator`, all `internal`, all reachable from
+`src/test`:
+
+- `CalculatorKey` — enum of the keys above.
+- `ExpressionEvaluator` — recursive descent over `BigDecimal`, taking a canonical ASCII string.
+  Output: a sealed `EvalResult` (`Success(BigDecimal)` / `Failure`). Recursive descent rather than
+  shunting-yard: precedence, parentheses and the unary minus all fall out of the grammar, so it is
+  shorter than a tokeniser plus an RPN pass and has no intermediate representation to get wrong.
+  A single `Failure` carries no reason — nothing consumes one, and a per-reason message would need
+  user-facing strings to localise.
+- `CalculatorState` — immutable state machine: `press(key): CalculatorState`, holding the canonical
+  expression and answering `result(scale)`. Holds no view reference and knows nothing about locale.
+- `CalculatorPopup` — the only class that touches Android: inflates the layout, wires clicks to
+  `CalculatorState`, anchors the `PopupWindow`.
+
+The views stay thin: they own the button and hand `CalculatorPopup` a value in and a value out.
+All arithmetic, formatting of the expression line, and key semantics live in the two testable
+classes.
+
+`library/build.gradle` — add `ru.pravbeseda.currencyedittext.calculator.*` to the Kover include
+filter next to `watchers.*` and `util.*`, so the new code counts towards `minBound(80)`.
+
+## PR 1 — evaluator and state machine, no UI
+
+Branch: `feat/calculator-core`.
+
+1. Write `ExpressionEvaluatorTest` first and watch it fail: precedence (`100 + 2 × 50 = 200`),
+   parentheses, unary minus, `100 ÷ 3 × 3 = 100.00` at scale 2, division by zero, unbalanced
+   parentheses, trailing operator.
+   Verify: red run recorded, then `./gradlew :library:testDebugUnitTest` green (the plain
+   `:library:test` task takes no `--tests` filter).
+2. Implement `CalculatorKey`, `EvalResult`, `ExpressionEvaluator`.
+3. Write `CalculatorStateTest` first: key sequences, `±` on the current operand, `±` twice,
+   `⌫` across an operator, `C`, `=` on an incomplete expression, seeding from an initial value.
+   Verify: red run recorded, then green.
+4. Implement `CalculatorState`.
+5. Add the Kover filter entry.
+   Verify: `./gradlew :library:koverVerifyDebug :library:koverLogDebug` — the new package is listed
+   and the bound holds.
+
+Done when `./gradlew build` passes locally and `library/api/library.api` is unchanged (everything
+here is `internal`).
+
+## PR 2 — the panel, the button and the attribute
+
+Branch: `feat/calculator-panel`.
+
+1. Add `calculatorEnabled` to both `declare-styleable` blocks in `res-public/values/attrs.xml`.
+2. Add the panel layout and the button drawable under `library/src/main/res/`.
+   Verify: `library/src/main/res-public/values/public.xml` still lists nothing, so the new
+   resources stay private to the artifact.
+3. Implement `CalculatorPopup`.
+4. `CurrencyEditText`: read the attribute in `init`, add `setCalculatorEnabled` /
+   `isCalculatorEnabled`, draw the button as a compound drawable and handle the tap. The
+   attribute changes no watcher configuration, so it must **not** call `invalidateTextWatcher()`.
+5. `CurrencyMaterialEditText`: read the attribute in `init`, delegate the setter and getter, and
+   render the button through `TextInputLayout`'s `END_ICON_CUSTOM` rather than a compound drawable.
+6. Instrumented tests in both `CurrencyEditTextTest` and `CurrencyMaterialEditTextTest`: the
+   default value of `calculatorEnabled` is `false`, and enabling it shows the button.
+   Verify: `./gradlew :library:connectedAndroidTest` on an API 24 emulator.
+7. `./gradlew :library:updateKotlinAbi` and commit the diff.
+   Verify: the diff contains only the four new public members, nothing else.
+8. Update `CLAUDE.md` (Architecture: the new package and the fact that `calculatorEnabled` is the
+   one attribute that does not go through `invalidateTextWatcher`) and the README.
+
+Done when `./gradlew build` passes locally, the instrumented tests pass, and the ABI diff is
+reviewed.
+
+**Public API change** (for the PR description): `calculatorEnabled` XML attribute on both views;
+`setCalculatorEnabled(Boolean)` and `isCalculatorEnabled(): Boolean` on both views. Additive only —
+no existing signature changes.
+
+## Risks
+
+- Popup placement: not enough room below the field means flipping above it. Check on a short
+  screen in landscape before merging PR 2.
+
+`res-public/values/public.xml` was suspected of marking every resource in the AAR private. It does
+not: an empty `<resources>` element makes AGP emit no `public.txt` at all, and the published AAR
+contains none, so every resource stays public. The file is inert, not harmful.

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,6 +77,7 @@ kover {
         filters {
             includes {
                 classes(
+                        'ru.pravbeseda.currencyedittext.calculator.*',
                         'ru.pravbeseda.currencyedittext.watchers.*',
                         'ru.pravbeseda.currencyedittext.util.*'
                 )

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+/**
+ * A key of the calculator panel. [symbol] is what the key appends to the expression; for the three
+ * editing keys, which append nothing, it is the label the panel draws on the button.
+ */
+internal enum class CalculatorKey(
+    val symbol: Char,
+) {
+    DIGIT_0('0'),
+    DIGIT_1('1'),
+    DIGIT_2('2'),
+    DIGIT_3('3'),
+    DIGIT_4('4'),
+    DIGIT_5('5'),
+    DIGIT_6('6'),
+    DIGIT_7('7'),
+    DIGIT_8('8'),
+    DIGIT_9('9'),
+    DECIMAL('.'),
+    PLUS('+'),
+    MINUS('-'),
+    MULTIPLY('*'),
+    DIVIDE('/'),
+    OPEN_PAREN('('),
+    CLOSE_PAREN(')'),
+    SIGN('±'),
+    BACKSPACE('⌫'),
+    CLEAR('C'),
+}

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
@@ -28,6 +28,9 @@ private val OPERATOR_KEYS =
 /** Characters after which an operand — and therefore a unary minus — may start. */
 private const val OPERAND_MAY_FOLLOW = "+-*/("
 
+/** The binary operators, and therefore also the characters a pending sign can be written among. */
+private const val OPERATORS = "+-*/"
+
 private fun Char.isOperandChar(): Boolean = isDigit() || this == '.'
 
 private fun Char?.mayPrecedeOperand(): Boolean = this != null && this in OPERAND_MAY_FOLLOW
@@ -77,21 +80,24 @@ internal data class CalculatorState(
             else -> CalculatorState("$expression.")
         }
 
-    private fun appendOperator(operator: Char): CalculatorState =
-        when {
-            // A minus may open an expression or a parenthesis; the others need a left operand.
-            expression.isEmpty() || lastChar == '(' -> {
-                if (operator == '-') CalculatorState(expression + operator) else this
-            }
-
-            lastChar.mayPrecedeOperand() -> {
-                CalculatorState(expression.dropLast(1) + operator)
+    /**
+     * Replaces everything still pending at the end — an operator, and the sign `flipSign` may have
+     * written after it — so that `1*-` plus `+` is `1+` and never `1*+`. Where no operand has
+     * started yet, only a minus is legal, and any other operator leaves the expression alone.
+     */
+    private fun appendOperator(operator: Char): CalculatorState {
+        val pending = expression.takeLastWhile { it in OPERATORS }
+        val settled = expression.dropLast(pending.length)
+        return when {
+            settled.isEmpty() || settled.last() == '(' -> {
+                if (operator == '-') CalculatorState("$settled-") else this
             }
 
             else -> {
-                CalculatorState(expression + operator)
+                CalculatorState(settled + operator)
             }
         }
+    }
 
     private fun appendOpeningParenthesis(): CalculatorState =
         if (expression.isEmpty() || lastChar.mayPrecedeOperand()) {

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import java.math.BigDecimal
+
+private val OPERATOR_KEYS =
+    setOf(
+        CalculatorKey.PLUS,
+        CalculatorKey.MINUS,
+        CalculatorKey.MULTIPLY,
+        CalculatorKey.DIVIDE,
+    )
+
+/** Characters after which an operand — and therefore a unary minus — may start. */
+private const val OPERAND_MAY_FOLLOW = "+-*/("
+
+private fun Char.isOperandChar(): Boolean = isDigit() || this == '.'
+
+private fun Char?.mayPrecedeOperand(): Boolean = this != null && this in OPERAND_MAY_FOLLOW
+
+private fun String.withCharAt(
+    index: Int,
+    char: Char,
+): String = substring(0, index) + char + substring(index + 1)
+
+/**
+ * What the calculator panel has been given so far, as a canonical ASCII expression. Holds no
+ * reference to a view and knows nothing about locale: the panel translates the user's decimal
+ * separator into `.` on the way in, and draws `*` and `/` as `×` and `÷` on the way out.
+ *
+ * Every key press returns a new state; a press that would make the expression unreadable — a
+ * second decimal point in one operand, a digit glued to a closing parenthesis — returns the state
+ * unchanged rather than a mess the user has to back out of.
+ */
+internal data class CalculatorState(
+    val expression: String = "",
+) {
+    fun press(key: CalculatorKey): CalculatorState =
+        when (key) {
+            CalculatorKey.CLEAR -> CalculatorState()
+            CalculatorKey.BACKSPACE -> CalculatorState(expression.dropLast(1))
+            CalculatorKey.SIGN -> flipSign()
+            CalculatorKey.DECIMAL -> appendDecimal()
+            CalculatorKey.OPEN_PAREN -> appendOpeningParenthesis()
+            CalculatorKey.CLOSE_PAREN -> appendClosingParenthesis()
+            in OPERATOR_KEYS -> appendOperator(key.symbol)
+            else -> appendDigit(key.symbol)
+        }
+
+    fun result(scale: Int): EvalResult = ExpressionEvaluator.evaluate(expression, scale)
+
+    private val lastChar: Char? get() = expression.lastOrNull()
+
+    /** The run of digits and decimal points at the end — what the user is typing right now. */
+    private val currentOperand: String get() = expression.takeLastWhile { it.isOperandChar() }
+
+    private fun appendDigit(digit: Char): CalculatorState = if (lastChar == ')') this else CalculatorState(expression + digit)
+
+    private fun appendDecimal(): CalculatorState =
+        when {
+            lastChar == ')' || currentOperand.contains('.') -> this
+            currentOperand.isEmpty() -> CalculatorState("${expression}0.")
+            else -> CalculatorState("$expression.")
+        }
+
+    private fun appendOperator(operator: Char): CalculatorState =
+        when {
+            // A minus may open an expression or a parenthesis; the others need a left operand.
+            expression.isEmpty() || lastChar == '(' -> {
+                if (operator == '-') CalculatorState(expression + operator) else this
+            }
+
+            lastChar.mayPrecedeOperand() -> {
+                CalculatorState(expression.dropLast(1) + operator)
+            }
+
+            else -> {
+                CalculatorState(expression + operator)
+            }
+        }
+
+    private fun appendOpeningParenthesis(): CalculatorState =
+        if (expression.isEmpty() || lastChar.mayPrecedeOperand()) {
+            CalculatorState("$expression(")
+        } else {
+            this
+        }
+
+    private fun appendClosingParenthesis(): CalculatorState {
+        val unclosed = expression.count { it == '(' } - expression.count { it == ')' }
+        val operandFinished = lastChar?.let { it.isDigit() || it == ')' } == true
+        return if (unclosed > 0 && operandFinished) CalculatorState("$expression)") else this
+    }
+
+    /**
+     * Flips the sign of the operand being entered. A unary `-` in front of that operand is
+     * removed; a binary `+` or `-` in front of it is flipped instead, so that `100-50` becomes
+     * `100+50` rather than the unreadable `100--50`. Only `*` and `/`, which cannot absorb a sign,
+     * get a unary minus written after them.
+     */
+    private fun flipSign(): CalculatorState {
+        if (lastChar == ')') return this
+        val start = expression.length - currentOperand.length
+        val preceding = expression.getOrNull(start - 1)
+        return when {
+            isUnaryMinusBefore(start) -> CalculatorState(expression.removeRange(start - 1, start))
+            preceding == '+' -> CalculatorState(expression.withCharAt(start - 1, '-'))
+            preceding == '-' -> CalculatorState(expression.withCharAt(start - 1, '+'))
+            else -> CalculatorState(expression.substring(0, start) + '-' + currentOperand)
+        }
+    }
+
+    private fun isUnaryMinusBefore(start: Int): Boolean =
+        start > 0 &&
+            expression[start - 1] == '-' &&
+            (start == 1 || expression[start - 2] in OPERAND_MAY_FOLLOW)
+
+    companion object {
+        /**
+         * Seeds the panel with the field's value. A zero field seeds nothing: the user is about to
+         * type a number, not to build on a `0` they never entered.
+         */
+        fun seededWith(value: BigDecimal): CalculatorState =
+            if (value.signum() == 0) CalculatorState() else CalculatorState(value.toPlainString())
+    }
+}

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluator.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluator.kt
@@ -48,9 +48,11 @@ internal object ExpressionEvaluator {
 }
 
 /**
- * Significant digits kept between operations. Wider than any field's scale on purpose, so that a
- * division in the middle of an expression does not round away digits a later multiplication needs
- * back: `100 / 3 * 3` has to end at 100.00, not 99.99.
+ * Significant digits a division keeps. Addition, subtraction and multiplication are exact and take
+ * no context at all; only division has to be told when to stop, or `10 / 3` never terminates. The
+ * figure is wider than any field's scale on purpose, so that a division in the middle of an
+ * expression does not round away digits a later multiplication needs back: `100 / 3 * 3` has to
+ * end at 100.00, not 99.99.
  */
 private const val INTERMEDIATE_PRECISION = 16
 
@@ -99,7 +101,7 @@ private class Parser(
             left =
                 when {
                     right == null -> null
-                    times -> left.multiply(right, INTERMEDIATE_MATH)
+                    times -> left.multiply(right)
                     right.signum() == 0 -> null
                     else -> left.divide(right, INTERMEDIATE_MATH)
                 }

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluator.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluator.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import java.math.BigDecimal
+import java.math.MathContext
+import java.math.RoundingMode
+
+internal sealed interface EvalResult {
+    data class Success(
+        val value: BigDecimal,
+    ) : EvalResult
+
+    data object Failure : EvalResult
+}
+
+/**
+ * Evaluates an arithmetic expression written with ASCII `+ - * / ( ) .` and digits.
+ * Locale-specific separators are the caller's business: the panel translates what the user
+ * typed into this canonical form.
+ */
+internal object ExpressionEvaluator {
+    fun evaluate(
+        expression: String,
+        scale: Int,
+    ): EvalResult {
+        val parser = Parser(expression)
+        val value = parser.parseSum()
+        return if (value == null || !parser.atEnd) {
+            EvalResult.Failure
+        } else {
+            EvalResult.Success(value.setScale(scale, RoundingMode.HALF_UP))
+        }
+    }
+}
+
+/**
+ * Significant digits kept between operations. Wider than any field's scale on purpose, so that a
+ * division in the middle of an expression does not round away digits a later multiplication needs
+ * back: `100 / 3 * 3` has to end at 100.00, not 99.99.
+ */
+private const val INTERMEDIATE_PRECISION = 16
+
+private val INTERMEDIATE_MATH = MathContext(INTERMEDIATE_PRECISION, RoundingMode.HALF_UP)
+
+/**
+ * Recursive descent over the grammar
+ * `sum := product (('+' | '-') product)*`,
+ * `product := factor (('*' | '/') factor)*`,
+ * `factor := '-' factor | '(' sum ')' | number`.
+ * Precedence and the unary minus fall out of the grammar. A `null` anywhere means the input is
+ * malformed or divides by zero, and it propagates: once an operand fails to parse the loops stop
+ * and the whole expression is null.
+ */
+private class Parser(
+    private val input: String,
+) {
+    private var pos = 0
+
+    val atEnd: Boolean get() = pos == input.length
+
+    private fun nextIsOneOf(operators: String): Boolean = !atEnd && input[pos] in operators
+
+    fun parseSum(): BigDecimal? {
+        var left = parseProduct()
+        while (left != null && nextIsOneOf("+-")) {
+            val plus = input[pos] == '+'
+            pos++
+            val right = parseProduct()
+            left =
+                when {
+                    right == null -> null
+                    plus -> left.add(right)
+                    else -> left.subtract(right)
+                }
+        }
+        return left
+    }
+
+    private fun parseProduct(): BigDecimal? {
+        var left = parseFactor()
+        while (left != null && nextIsOneOf("*/")) {
+            val times = input[pos] == '*'
+            pos++
+            val right = parseFactor()
+            left =
+                when {
+                    right == null -> null
+                    times -> left.multiply(right, INTERMEDIATE_MATH)
+                    right.signum() == 0 -> null
+                    else -> left.divide(right, INTERMEDIATE_MATH)
+                }
+        }
+        return left
+    }
+
+    private fun parseFactor(): BigDecimal? {
+        if (atEnd) return null
+        return when {
+            input[pos] == '-' -> {
+                pos++
+                parseFactor()?.negate()
+            }
+
+            input[pos] == '(' -> {
+                pos++
+                parseParenthesised()
+            }
+
+            else -> {
+                parseNumber()
+            }
+        }
+    }
+
+    private fun parseParenthesised(): BigDecimal? {
+        val value = parseSum()
+        val closes = value != null && !atEnd && input[pos] == ')'
+        if (!closes) return null
+        pos++
+        return value
+    }
+
+    private fun parseNumber(): BigDecimal? {
+        val start = pos
+        while (!atEnd && (input[pos].isDigit() || input[pos] == '.')) pos++
+        return input.substring(start, pos).toBigDecimalOrNull()
+    }
+}

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.BACKSPACE
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.CLEAR
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.CLOSE_PAREN
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DECIMAL
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIGIT_0
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIGIT_1
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIGIT_2
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIGIT_3
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIGIT_5
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.DIVIDE
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.MINUS
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.MULTIPLY
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.OPEN_PAREN
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.PLUS
+import ru.pravbeseda.currencyedittext.calculator.CalculatorKey.SIGN
+import java.math.BigDecimal
+
+class CalculatorStateTest {
+    @Test
+    fun `digits append to the expression`() {
+        assertEquals("123", press(DIGIT_1, DIGIT_2, DIGIT_3))
+    }
+
+    @Test
+    fun `operators append between operands`() {
+        assertEquals("1+2", press(DIGIT_1, PLUS, DIGIT_2))
+    }
+
+    @Test
+    fun `a trailing operator is replaced rather than doubled`() {
+        assertEquals("1*", press(DIGIT_1, PLUS, MULTIPLY))
+    }
+
+    @Test
+    fun `a leading minus starts a negative operand, other operators are ignored`() {
+        assertEquals("-", press(MINUS))
+        assertEquals("", press(PLUS))
+        assertEquals("", press(MULTIPLY))
+        assertEquals("", press(DIVIDE))
+    }
+
+    @Test
+    fun `the decimal key opens a fraction and cannot be repeated in one operand`() {
+        assertEquals("1.2", press(DIGIT_1, DECIMAL, DIGIT_2))
+        assertEquals("1.2", press(DIGIT_1, DECIMAL, DIGIT_2, DECIMAL))
+        assertEquals("1.2+3.5", press(DIGIT_1, DECIMAL, DIGIT_2, PLUS, DIGIT_3, DECIMAL, DIGIT_5))
+    }
+
+    @Test
+    fun `the decimal key on an empty operand writes a leading zero`() {
+        assertEquals("0.5", press(DECIMAL, DIGIT_5))
+        assertEquals("1+0.5", press(DIGIT_1, PLUS, DECIMAL, DIGIT_5))
+    }
+
+    @Test
+    fun `sign flips the operand being entered and flips it back`() {
+        assertEquals("-100", press(DIGIT_1, DIGIT_0, DIGIT_0, SIGN))
+        assertEquals("100", press(DIGIT_1, DIGIT_0, DIGIT_0, SIGN, SIGN))
+    }
+
+    @Test
+    fun `sign flips only the last operand`() {
+        assertEquals("100*-3", press(DIGIT_1, DIGIT_0, DIGIT_0, MULTIPLY, DIGIT_3, SIGN))
+        assertEquals("100*3", press(DIGIT_1, DIGIT_0, DIGIT_0, MULTIPLY, DIGIT_3, SIGN, SIGN))
+    }
+
+    @Test
+    fun `sign flips the preceding plus or minus instead of writing a double sign`() {
+        assertEquals("100+50", press(DIGIT_1, DIGIT_0, DIGIT_0, MINUS, DIGIT_5, DIGIT_0, SIGN))
+        assertEquals("100-50", press(DIGIT_1, DIGIT_0, DIGIT_0, PLUS, DIGIT_5, DIGIT_0, SIGN))
+        assertEquals(BigDecimal("150.00"), value("100+50"))
+    }
+
+    @Test
+    fun `flipping the preceding operator twice returns the original expression`() {
+        assertEquals(
+            "100-50",
+            press(DIGIT_1, DIGIT_0, DIGIT_0, MINUS, DIGIT_5, DIGIT_0, SIGN, SIGN),
+        )
+    }
+
+    @Test
+    fun `sign after a trailing plus or minus flips that operator`() {
+        assertEquals("100-", press(DIGIT_1, DIGIT_0, DIGIT_0, PLUS, SIGN))
+        assertEquals("100+", press(DIGIT_1, DIGIT_0, DIGIT_0, MINUS, SIGN))
+    }
+
+    @Test
+    fun `sign after a multiplication opens a negative operand, as no operator can absorb it`() {
+        assertEquals("100*-", press(DIGIT_1, DIGIT_0, DIGIT_0, MULTIPLY, SIGN))
+        assertEquals("100*", press(DIGIT_1, DIGIT_0, DIGIT_0, MULTIPLY, SIGN, SIGN))
+    }
+
+    @Test
+    fun `sign on an empty expression starts a negative operand`() {
+        assertEquals("-", press(SIGN))
+        assertEquals("", press(SIGN, SIGN))
+    }
+
+    @Test
+    fun `sign is ignored right after a closing parenthesis`() {
+        assertEquals("(1+2)", press(OPEN_PAREN, DIGIT_1, PLUS, DIGIT_2, CLOSE_PAREN, SIGN))
+    }
+
+    @Test
+    fun `an opening parenthesis is allowed only where an operand may start`() {
+        assertEquals("(", press(OPEN_PAREN))
+        assertEquals("1*(", press(DIGIT_1, MULTIPLY, OPEN_PAREN))
+        assertEquals("1", press(DIGIT_1, OPEN_PAREN))
+    }
+
+    @Test
+    fun `a closing parenthesis needs an open one and a finished operand`() {
+        assertEquals("(1+2)", press(OPEN_PAREN, DIGIT_1, PLUS, DIGIT_2, CLOSE_PAREN))
+        assertEquals("(1+", press(OPEN_PAREN, DIGIT_1, PLUS, CLOSE_PAREN))
+        assertEquals("1", press(DIGIT_1, CLOSE_PAREN))
+    }
+
+    @Test
+    fun `digits are ignored right after a closing parenthesis`() {
+        assertEquals("(1)", press(OPEN_PAREN, DIGIT_1, CLOSE_PAREN, DIGIT_2))
+        assertEquals("(1)", press(OPEN_PAREN, DIGIT_1, CLOSE_PAREN, DECIMAL))
+        assertEquals("(1)", press(OPEN_PAREN, DIGIT_1, CLOSE_PAREN, OPEN_PAREN))
+    }
+
+    @Test
+    fun `backspace removes one character and stops at an empty expression`() {
+        assertEquals("1+", press(DIGIT_1, PLUS, DIGIT_2, BACKSPACE))
+        assertEquals("", press(DIGIT_1, BACKSPACE, BACKSPACE))
+    }
+
+    @Test
+    fun `clear empties the expression`() {
+        assertEquals("", press(DIGIT_1, PLUS, DIGIT_2, CLEAR))
+    }
+
+    @Test
+    fun `the panel opens seeded with the field's value`() {
+        assertEquals("100.50", CalculatorState.seededWith(BigDecimal("100.50")).expression)
+        assertEquals("-7", CalculatorState.seededWith(BigDecimal("-7")).expression)
+    }
+
+    @Test
+    fun `a zero field seeds an empty expression rather than a stray zero`() {
+        assertEquals("", CalculatorState.seededWith(BigDecimal.ZERO).expression)
+        assertEquals("", CalculatorState.seededWith(BigDecimal("0.00")).expression)
+    }
+
+    @Test
+    fun `the result is the evaluated expression at the field's scale`() {
+        assertEquals(EvalResult.Success(BigDecimal("200.00")), result("100+2*50"))
+        assertEquals(EvalResult.Failure, result("1+"))
+        assertEquals(EvalResult.Failure, result(""))
+    }
+
+    private fun press(vararg keys: CalculatorKey): String = keys.fold(CalculatorState()) { state, key -> state.press(key) }.expression
+
+    private fun result(expression: String): EvalResult = CalculatorState(expression).result(scale = 2)
+
+    private fun value(expression: String): BigDecimal = (result(expression) as EvalResult.Success).value
+}

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
@@ -51,6 +51,18 @@ class CalculatorStateTest {
     }
 
     @Test
+    fun `an operator replaces a pending sign as well as the operator carrying it`() {
+        assertEquals("1*", press(DIGIT_1, MULTIPLY, SIGN, MULTIPLY))
+        assertEquals("1+", press(DIGIT_1, MULTIPLY, SIGN, PLUS))
+    }
+
+    @Test
+    fun `an operator cannot turn a leading or bracketed minus into another sign`() {
+        assertEquals("-", press(MINUS, PLUS))
+        assertEquals("(-", press(OPEN_PAREN, MINUS, PLUS))
+    }
+
+    @Test
     fun `a leading minus starts a negative operand, other operators are ignored`() {
         assertEquals("-", press(MINUS))
         assertEquals("", press(PLUS))

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluatorTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluatorTest.kt
@@ -56,6 +56,11 @@ class ExpressionEvaluatorTest {
     }
 
     @Test
+    fun `multiplication is exact, however many digits the operands carry`() {
+        assertEquals(success("89999999999999991.00"), evaluate("9999999999999999*9", scale = 2))
+    }
+
+    @Test
     fun `intermediate division keeps precision the final scale would lose`() {
         assertEquals(success("100.00"), evaluate("100/3*3", scale = 2))
     }

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluatorTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/ExpressionEvaluatorTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+
+class ExpressionEvaluatorTest {
+    @Test
+    fun `multiplication binds tighter than addition`() {
+        assertEquals(success("200.00"), evaluate("100+2*50", scale = 2))
+    }
+
+    @Test
+    fun `parentheses override precedence`() {
+        assertEquals(success("5100.00"), evaluate("(100+2)*50", scale = 2))
+    }
+
+    @Test
+    fun `division binds tighter than subtraction`() {
+        assertEquals(success("90.00"), evaluate("100-20/2", scale = 2))
+    }
+
+    @Test
+    fun `leading minus is a unary sign`() {
+        assertEquals(success("-2.00"), evaluate("-5+3", scale = 2))
+    }
+
+    @Test
+    fun `unary minus applies after an operator`() {
+        assertEquals(success("-15.00"), evaluate("5*-3", scale = 2))
+    }
+
+    @Test
+    fun `unary minus applies inside parentheses`() {
+        assertEquals(success("-8.00"), evaluate("2*(-7+3)", scale = 2))
+    }
+
+    @Test
+    fun `decimals are exact, unlike double arithmetic`() {
+        assertEquals(success("0.30"), evaluate("0.1+0.2", scale = 2))
+    }
+
+    @Test
+    fun `intermediate division keeps precision the final scale would lose`() {
+        assertEquals(success("100.00"), evaluate("100/3*3", scale = 2))
+    }
+
+    @Test
+    fun `the result is rounded half up to the requested scale`() {
+        assertEquals(success("3.33"), evaluate("10/3", scale = 2))
+        assertEquals(success("3.333"), evaluate("10/3", scale = 3))
+        assertEquals(success("0.13"), evaluate("0.125", scale = 2))
+    }
+
+    @Test
+    fun `a scale of zero rounds to whole units`() {
+        assertEquals(success("3"), evaluate("10/3", scale = 0))
+    }
+
+    @Test
+    fun `division by zero fails instead of throwing`() {
+        assertEquals(EvalResult.Failure, evaluate("10/0", scale = 2))
+        assertEquals(EvalResult.Failure, evaluate("10/(5-5)", scale = 2))
+    }
+
+    @Test
+    fun `an unbalanced expression fails`() {
+        assertEquals(EvalResult.Failure, evaluate("(1+2", scale = 2))
+        assertEquals(EvalResult.Failure, evaluate("1+2)", scale = 2))
+    }
+
+    @Test
+    fun `an incomplete expression fails`() {
+        assertEquals(EvalResult.Failure, evaluate("1+", scale = 2))
+        assertEquals(EvalResult.Failure, evaluate("", scale = 2))
+        assertEquals(EvalResult.Failure, evaluate("()", scale = 2))
+    }
+
+    @Test
+    fun `an unknown character fails`() {
+        assertEquals(EvalResult.Failure, evaluate("1+a", scale = 2))
+        assertEquals(EvalResult.Failure, evaluate("1,5+1", scale = 2))
+    }
+
+    @Test
+    fun `a bare number is returned at the requested scale`() {
+        assertEquals(success("42.00"), evaluate("42", scale = 2))
+    }
+
+    private fun evaluate(
+        expression: String,
+        scale: Int,
+    ): EvalResult = ExpressionEvaluator.evaluate(expression, scale)
+
+    private fun success(value: String): EvalResult = EvalResult.Success(BigDecimal(value))
+}


### PR DESCRIPTION
Groundwork for an optional calculator that both views will be able to open from a button at the
right edge of the field. This pull request adds the arithmetic and the key semantics only — no UI,
no new dependency, and no public API change: every class added here is `internal`.

The plan for both pull requests, including the survey of ready-made libraries that found nothing
usable, is in `.github/tasks/calculator-input-panel.md`.

## What is in it

- **`ExpressionEvaluator`** — recursive descent over `BigDecimal` for `+ - * / ( )` with a unary
  minus. Recursive descent rather than shunting-yard: precedence, parentheses and the unary minus
  all fall out of the grammar, so there is no tokeniser and no intermediate representation to get
  wrong. Division by zero and malformed input return `EvalResult.Failure`; nothing throws.
- **`CalculatorKey`** — the 20 keys of the panel. `symbol` is what a key appends; for `±`, `⌫` and
  `C` it is the label the panel will draw.
- **`CalculatorState`** — immutable state machine over a canonical ASCII expression. Holds no view
  reference and knows nothing about locale, so the panel translates the user's decimal separator
  on the way in and draws `×` and `÷` on the way out. A press that would make the expression
  unreadable — a second decimal point in one operand, a digit glued to a closing parenthesis — is
  ignored rather than accepted and left for the user to back out of.

## Two decisions worth a look

**Rounding.** Intermediate operations run at 16 significant digits, and only the final result is
rounded to the caller's scale, `HALF_UP`. Rounding every step to the field's scale instead would
make `100 ÷ 3 × 3` come out at 99.99, and the error would accumulate silently down a long
expression.

**The sign key never writes a double sign.** A unary `-` in front of the operand is removed; a
binary `+` or `-` in front of it is flipped instead, so `100-50` becomes `100+50` and not
`100--50`. Only `*` and `/`, which cannot absorb a sign, get a unary minus written after them.
The operation is reversible in both directions.

| Expression | `±` | Result |
|---|---|---|
| `100-50` | → | `100+50` |
| `100+50` | → | `100-50` |
| `100+` | → | `100-` |
| `100*3` | → | `100*-3` |
| `100` | → | `-100` |

## Tests

37 new tests, written before the implementation and watched failing first — `EvalResult` and
`ExpressionEvaluator` unresolved, then `CalculatorKey` unresolved, then the two rewritten sign
tests failing on the old double-sign behaviour.

Coverage on `:library` is filtered by package, so `…currencyedittext.calculator.*` joins
`watchers.*` and `util.*` in the Kover include list. The filtered figure is 94.23%, against the
`minBound(80)` floor.

## Quality gates

`./gradlew build` passes locally. detekt reported `ReturnCount`, `MagicNumber`, `ComplexCondition`
and `TooManyFunctions` along the way; all four are fixed in the code — no `@Suppress`, no baseline
entry, no lowered bound.

`library/api/library.api` is unchanged, as it should be for an all-`internal` addition.

## Not in this pull request

The `PopupWindow` panel, the button, the `calculatorEnabled` attribute and the public setters —
those are PR 2, and they are what will change the ABI.
