### PR TITLE
fix(sample): inset the content for the system bars on Android 15+

### DIFF
--- a/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
+++ b/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import pravbeseda.databinding.ActivityMainBinding
 import ru.pravbeseda.currencyedittext.CurrencyEditText.Companion.State
@@ -82,8 +83,8 @@ class MainActivity : AppCompatActivity() {
     private fun applySystemBarInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.statusBarBackground.updateLayoutParams { height = systemBars.top }
             binding.toolbar.updatePadding(
-                top = systemBars.top,
                 left = systemBars.left,
                 right = systemBars.right,
             )

--- a/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
+++ b/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
@@ -82,8 +82,16 @@ class MainActivity : AppCompatActivity() {
     private fun applySystemBarInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            binding.toolbar.updatePadding(top = systemBars.top)
-            binding.root.updatePadding(bottom = systemBars.bottom)
+            binding.toolbar.updatePadding(
+                top = systemBars.top,
+                left = systemBars.left,
+                right = systemBars.right,
+            )
+            binding.content.updatePadding(
+                left = systemBars.left,
+                right = systemBars.right,
+                bottom = systemBars.bottom,
+            )
             insets
         }
     }

--- a/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
+++ b/sample/src/main/java/ru/pravbeseda/currencyedittext/MainActivity.kt
@@ -18,6 +18,9 @@ package ru.pravbeseda.currencyedittext
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import pravbeseda.databinding.ActivityMainBinding
 import ru.pravbeseda.currencyedittext.CurrencyEditText.Companion.State
 import ru.pravbeseda.currencyedittext.model.CurrencyFormatConfig
@@ -32,6 +35,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+        applySystemBarInsets()
 
         binding.currencyEditText.setValue(BigDecimal(1123.476))
         binding.currencyMaterialEditText.setValue(BigDecimal(1432.167))
@@ -69,6 +74,17 @@ class MainActivity : AppCompatActivity() {
                 error = "Value can't be less than the first field"
             }
             error
+        }
+    }
+
+    // Targeting SDK 35+ makes the window edge-to-edge: without this the system bars
+    // are drawn over the content.
+    private fun applySystemBarInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.toolbar.updatePadding(top = systemBars.top)
+            binding.root.updatePadding(bottom = systemBars.bottom)
+            insets
         }
     }
 

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -6,6 +6,18 @@
     android:layout_height="match_parent"
     tools:context="ru.pravbeseda.currencyedittext.MainActivity">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
     <TextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
@@ -18,7 +30,7 @@
         android:textSize="22sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
     <ru.pravbeseda.currencyedittext.CurrencyEditText
         android:id="@+id/currencyEditText"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -7,6 +7,12 @@
     android:orientation="vertical"
     tools:context="ru.pravbeseda.currencyedittext.MainActivity">
 
+    <View
+        android:id="@+id/statusBarBackground"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@color/colorPrimaryDark" />
+
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,89 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context="ru.pravbeseda.currencyedittext.MainActivity">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/value"
-        android:textColor="@android:color/black"
-        android:textSize="22sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/content"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
-    <ru.pravbeseda.currencyedittext.CurrencyEditText
-        android:id="@+id/currencyEditText"
-        android:layout_width="200dp"
-        android:layout_height="60dp"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="0dp"
-        android:layout_marginEnd="60dp"
-        android:layout_marginBottom="20dp"
-        android:selectAllOnFocus="true"
-        app:currencySymbol="$"
-        app:negativeValueAllow="true"
-        app:maxNumberOfDecimalPlaces="2"
-        app:decimalZerosPadding="false"
-        app:localeTag="da-DK"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView"
-        app:useCurrencySymbolAsHint="true" />
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/value"
+            android:textColor="@android:color/black"
+            android:textSize="22sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="8dp"
-        android:text="Clear"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/currencyEditText" />
+        <ru.pravbeseda.currencyedittext.CurrencyEditText
+            android:id="@+id/currencyEditText"
+            android:layout_width="200dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="60dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginEnd="60dp"
+            android:layout_marginBottom="20dp"
+            android:selectAllOnFocus="true"
+            app:currencySymbol="$"
+            app:negativeValueAllow="true"
+            app:maxNumberOfDecimalPlaces="2"
+            app:decimalZerosPadding="false"
+            app:localeTag="da-DK"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView"
+            app:useCurrencySymbolAsHint="true" />
 
-    <ru.pravbeseda.currencyedittext.CurrencyMaterialEditText
-        android:id="@+id/currencyMaterialEditText"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="60dp"
-        android:layout_marginBottom="20dp"
-        android:hint="CurrencyMaterialEditText"
-        app:decimalSeparator=","
-        app:groupingSeparator=" "
-        app:selectAllOnFocus="true"
-        app:maxNumberOfDecimalPlaces="2"
-        app:decimalZerosPadding="false"
-        android:importantForAutofill="noExcludeDescendants"
-        android:textAlignment="viewStart"
-        android:theme="@style/CustomThemeEditText"
-        app:negativeValueAllow="true"
-        app:errorEnabled="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/button" />
+        <Button
+            android:id="@+id/button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="8dp"
+            android:text="Clear"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/currencyEditText" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ru.pravbeseda.currencyedittext.CurrencyMaterialEditText
+            android:id="@+id/currencyMaterialEditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="60dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="60dp"
+            android:layout_marginBottom="20dp"
+            android:hint="CurrencyMaterialEditText"
+            app:decimalSeparator=","
+            app:groupingSeparator=" "
+            app:selectAllOnFocus="true"
+            app:maxNumberOfDecimalPlaces="2"
+            app:decimalZerosPadding="false"
+            android:importantForAutofill="noExcludeDescendants"
+            android:textAlignment="viewStart"
+            android:theme="@style/CustomThemeEditText"
+            app:negativeValueAllow="true"
+            app:errorEnabled="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/button" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
## What

The sample app drew its content under the app bar on Android 15+: the `Value` label was fully
hidden and the top of `CurrencyEditText` was clipped (issue #37).

Reproduced on an API 36 emulator (1080x2400) before the fix:

```
action_bar_container  [0,0][1080,210]     <- painted over the content
textView              [410,53][670,131]
currencyEditText      [278,131][803,289]
```

After:

```
toolbar               [0,0][1080,210]
textView              [410,263][670,341]
currencyEditText      [278,341][803,499]
```

## Why

`:sample` targets SDK 37, and from API 35 the platform enforces edge-to-edge. The decor action bar
of `Theme.AppCompat.Light.DarkActionBar` then stops offsetting the content below itself, so it is
painted straight over the first two widgets.

Note that the fix suggested in the issue — padding the root by the system bar insets alone — is not
enough on its own: that adds 63px (the status bar), while the app bar ends at y=210.

## How

- `styles.xml`: `Theme.AppCompat.Light.DarkActionBar` -> `Theme.AppCompat.Light.NoActionBar`.
- `activity_main.xml`: a vertical `LinearLayout` holding a `statusBarBackground` `View`, an
  `androidx.appcompat.widget.Toolbar` and a `content` `ConstraintLayout` with the previous widgets,
  unchanged.
- `MainActivity`: `setSupportActionBar(binding.toolbar)` plus a window insets listener — the top
  inset becomes the height of `statusBarBackground`, which carries `colorPrimaryDark` so the status
  bar keeps its own tint as it did under the old theme, and the toolbar and the content container
  take the horizontal insets, the container the bottom one as well.

`android:statusBarColor` is not an option here: the platform ignores it for apps targeting SDK 35
and above, so the strip behind the status bar has to be a view the app draws itself.

The two-level layout is what lets the bars stay full-bleed while the title and the content below
them are still inset: padding a single root sideways would cut those backgrounds short.

## Scope

`:sample` only. No change to the published `:library` artifact, and no public API change.

## Testing

`./gradlew build` passes locally (all six gates). Verified by hand on an API 36 emulator, with the
`uiautomator` dumps above, in portrait and in reverse landscape with three-button navigation
(nav bar at x=0..126, toolbar title at x=136); not verified on API 24-34, where the window is not
edge-to-edge and the insets reach the content as zero.

No tests, because the change is confined to the demo app's window handling — there is no logic in
`library/src/main` to cover, and `:sample` has no test source set.


