### PR TITLE
feat: opt-in calculator panel for both views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ Supporting pieces:
 - `util/Utils.kt` — `parseMoneyValue*`, `formatMoneyValue`, locale/API-level helpers (internal).
 - `util/Routines.kt` — public `Routines.bigDecimalToString(value, CurrencyFormatConfig)` for
   formatting outside the view; also the `emptyChar = 'n'` sentinel meaning "no grouping separator".
+- `calculator/` — the opt-in calculator panel, all `internal`: `CalculatorKey`,
+  `ExpressionEvaluator` (recursive descent over `BigDecimal`), `CalculatorState` (the immutable key
+  state machine, which also renders the expression line), and `CalculatorPopup` — the only class of
+  the package that touches Android, and therefore the only one excluded from the Kover filter.
 - `res-public/values/attrs.xml` — XML attributes; `library/build.gradle` adds `src/main/res-public`
   as a second res source dir.
 
@@ -130,6 +134,11 @@ Conventions that matter when editing the views:
 - A new XML attribute must be added in three places: `attrs.xml` (both `declare-styleable` blocks),
   the `init` block of `CurrencyEditText`, and the `init` block + delegating setter/getter of
   `CurrencyMaterialEditText`.
+- `calculatorEnabled` is the one attribute that must **not** call `invalidateTextWatcher()`: the
+  panel reads the field's configuration when it opens, so it changes nothing about the watcher.
+  It is also the one setting `CurrencyMaterialEditText` does not delegate to the inner view — the
+  layout draws the button itself, through `END_ICON_CUSTOM`, and the inner `CurrencyEditText` would
+  otherwise draw a second one as a compound drawable.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ expression that does not evaluate, divides by zero, or comes out negative in a f
 `negativeValueAllow="false"` leaves the field untouched. The system keyboard is not replaced: the
 field still takes typed input as before.
 
+On `CurrencyEditText` the button is drawn as a compound drawable and opens on a tap on the icon, so
+it is not a separate node for a screen reader. Where that matters, use `CurrencyMaterialEditText`:
+there the button is a real end icon with a content description.
+
 ## Localization
 
 The library supports localization. You can set the locale in the layout file:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,27 @@ edittext.onValueChanged { bigDecimal, state: State, textError: String ->
 
 In the CurrencyMaterialEditText component, the validation error text is shown automatically.
 
+## Calculator
+
+Both components can show a calculator button at the end of the field. It is off by default:
+
+```
+app:calculatorEnabled="true"
+```
+
+Or in the code:
+
+```Kotlin
+edittext.setCalculatorEnabled(true)
+```
+
+Tapping the button opens a panel under the field, seeded with the field's current value. It
+evaluates a full expression — `+ - x /`, parentheses, and a sign key that flips the operand being
+entered — and `=` writes the result back into the field, rounded to `maxNumberOfDecimalPlaces`. An
+expression that does not evaluate, divides by zero, or comes out negative in a field with
+`negativeValueAllow="false"` leaves the field untouched. The system keyboard is not replaced: the
+field still takes typed input as before.
+
 ## Localization
 
 The library supports localization. You can set the locale in the layout file:

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -8,11 +8,15 @@ public class ru/pravbeseda/currencyedittext/CurrencyEditText : androidx/appcompa
 	public final fun getNegativeValueAllow ()Z
 	public final fun getValue ()Ljava/math/BigDecimal;
 	public final fun getValue0 ()Ljava/math/BigDecimal;
+	public final fun isCalculatorEnabled ()Z
 	public final fun isValid ()Z
 	public final fun isValidState ()Z
 	protected fun onFocusChanged (ZILandroid/graphics/Rect;)V
 	protected fun onSelectionChanged (II)V
+	public fun onTouchEvent (Landroid/view/MotionEvent;)Z
 	public final fun onValueChanged (Lkotlin/jvm/functions/Function3;)V
+	public fun performClick ()Z
+	public final fun setCalculatorEnabled (Z)V
 	public final fun setCurrencySymbol (Ljava/lang/String;Z)V
 	public static synthetic fun setCurrencySymbol$default (Lru/pravbeseda/currencyedittext/CurrencyEditText;Ljava/lang/String;ZILjava/lang/Object;)V
 	public final fun setDecimalZerosPadding (Z)V
@@ -53,9 +57,11 @@ public class ru/pravbeseda/currencyedittext/CurrencyMaterialEditText : com/googl
 	public final fun getText ()Landroid/text/Editable;
 	public final fun getValue ()Ljava/math/BigDecimal;
 	public final fun getValue0 ()Ljava/math/BigDecimal;
+	public final fun isCalculatorEnabled ()Z
 	public final fun isValid ()Z
 	public final fun isValidState ()Z
 	public final fun onValueChanged (Lkotlin/jvm/functions/Function3;)V
+	public final fun setCalculatorEnabled (Z)V
 	public final fun setDecimalZerosPadding (Z)V
 	public final fun setEmptyStringForZero (Z)V
 	public final fun setLocale (Ljava/lang/String;)V

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -82,6 +82,16 @@ kover {
                         'ru.pravbeseda.currencyedittext.util.*'
                 )
             }
+            excludes {
+                // The calculator's panel is the one class of that package that
+                // touches Android, and it is out of the filter for the same
+                // reason as the two Views: src/test cannot reach it, so its
+                // lines would measure the size of the panel rather than the
+                // quality of the tests. Everything it decides — key semantics,
+                // arithmetic, the expression line — lives in CalculatorState
+                // and ExpressionEvaluator, which are measured.
+                classes('ru.pravbeseda.currencyedittext.calculator.CalculatorPopup')
+            }
         }
         variant('debug') {
             // Coverage lands in the build log of every `check`, so the number is

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -16,6 +16,10 @@
 package ru.pravbeseda.currencyedittext
 
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.SystemClock
+import android.view.MotionEvent
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -87,6 +91,51 @@ class CurrencyEditTextTest {
     }
 
     @Test
+    fun theHostsOwnDrawablesSurviveTheCalculatorButton() {
+        val hostIcon = ColorDrawable(Color.RED)
+        currencyEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(hostIcon, null, null, null)
+
+        currencyEditText.setCalculatorEnabled(true)
+        Assert.assertSame(hostIcon, currencyEditText.compoundDrawablesRelative[START_DRAWABLE])
+
+        currencyEditText.setCalculatorEnabled(false)
+        Assert.assertSame(hostIcon, currencyEditText.compoundDrawablesRelative[START_DRAWABLE])
+        Assert.assertNull(currencyEditText.compoundDrawablesRelative[END_DRAWABLE])
+    }
+
+    @Test
+    fun disablingACalculatorTheFieldNeverHadLeavesTheHostsEndDrawableAlone() {
+        val hostIcon = ColorDrawable(Color.RED)
+        currencyEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, hostIcon, null)
+
+        currencyEditText.setCalculatorEnabled(false)
+
+        Assert.assertSame(hostIcon, currencyEditText.compoundDrawablesRelative[END_DRAWABLE])
+    }
+
+    @Test
+    fun onlyAnEnabledFieldWithTheCalculatorOnOpensThePanel() {
+        currencyEditText.layout(0, 0, 200, 60)
+        currencyEditText.setCalculatorEnabled(true)
+        val onTheIcon = tapAt(currencyEditText.width.toFloat())
+
+        Assert.assertTrue(currencyEditText.opensCalculatorOn(onTheIcon))
+
+        currencyEditText.isEnabled = false
+        Assert.assertFalse(currencyEditText.opensCalculatorOn(onTheIcon))
+
+        currencyEditText.isEnabled = true
+        currencyEditText.setCalculatorEnabled(false)
+        currencyEditText.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            null,
+            null,
+            ColorDrawable(Color.RED).apply { setBounds(0, 0, 24, 24) },
+            null,
+        )
+        Assert.assertFalse(currencyEditText.opensCalculatorOn(onTheIcon))
+    }
+
+    @Test
     fun testSetText() {
         currencyEditText.setSeparators(' ', '.')
         setText("1 000.45")
@@ -155,8 +204,14 @@ class CurrencyEditTextTest {
         assertEquals(expected, currencyEditText.text.toString())
     }
 
+    private fun tapAt(x: Float): MotionEvent {
+        val now = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, x, 0f, 0)
+    }
+
     private companion object {
-        /** Index of the end drawable in `compoundDrawablesRelative`. */
+        /** Indices in `compoundDrawablesRelative`. */
+        const val START_DRAWABLE = 0
         const val END_DRAWABLE = 2
     }
 }

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -17,6 +17,7 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -66,6 +67,23 @@ class CurrencyEditTextTest {
         valuesAssertEquals()
         currencyEditText.setSeparators('^', '_')
         valuesAssertEquals()
+    }
+
+    @Test
+    fun calculatorIsOffByDefault() {
+        Assert.assertFalse(currencyEditText.isCalculatorEnabled())
+        Assert.assertNull(currencyEditText.compoundDrawablesRelative[END_DRAWABLE])
+    }
+
+    @Test
+    fun enablingTheCalculatorShowsTheButton() {
+        currencyEditText.setCalculatorEnabled(true)
+        Assert.assertTrue(currencyEditText.isCalculatorEnabled())
+        Assert.assertNotNull(currencyEditText.compoundDrawablesRelative[END_DRAWABLE])
+
+        currencyEditText.setCalculatorEnabled(false)
+        Assert.assertFalse(currencyEditText.isCalculatorEnabled())
+        Assert.assertNull(currencyEditText.compoundDrawablesRelative[END_DRAWABLE])
     }
 
     @Test
@@ -135,5 +153,10 @@ class CurrencyEditTextTest {
     ) {
         setText(text)
         assertEquals(expected, currencyEditText.text.toString())
+    }
+
+    private companion object {
+        /** Index of the end drawable in `compoundDrawablesRelative`. */
+        const val END_DRAWABLE = 2
     }
 }

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyEditTextTest.kt
@@ -101,8 +101,10 @@ class CurrencyEditTextTest {
         assertEquals("1,000.45", currencyEditText.text.toString())
     }
 
+    // Backtick names with spaces cannot be dexed below DEX 040, so instrumented
+    // tests spell the issue number out instead (#39).
     @Test
-    fun `Issue #23 - an empty field reads as zero`() {
+    fun issue23EmptyFieldReadsAsZero() {
         setText("")
         assertEquals(BigDecimal.ZERO, currencyEditText.getValue())
     }

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -17,6 +17,7 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.textfield.TextInputLayout
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -31,6 +32,28 @@ class CurrencyMaterialEditTextTest {
     fun init() {
         context.setTheme(com.google.android.material.R.style.Theme_MaterialComponents_Light)
         currencyEditText = CurrencyMaterialEditText(context, null)
+    }
+
+    @Test
+    fun calculatorIsOffByDefault() {
+        Assert.assertFalse(currencyEditText.isCalculatorEnabled())
+        Assert.assertEquals(TextInputLayout.END_ICON_NONE, currencyEditText.endIconMode)
+    }
+
+    @Test
+    fun enablingTheCalculatorShowsTheEndIcon() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            currencyEditText.setCalculatorEnabled(true)
+        }
+        Assert.assertTrue(currencyEditText.isCalculatorEnabled())
+        Assert.assertEquals(TextInputLayout.END_ICON_CUSTOM, currencyEditText.endIconMode)
+        Assert.assertNotNull(currencyEditText.endIconDrawable)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            currencyEditText.setCalculatorEnabled(false)
+        }
+        Assert.assertFalse(currencyEditText.isCalculatorEnabled())
+        Assert.assertEquals(TextInputLayout.END_ICON_NONE, currencyEditText.endIconMode)
     }
 
     @Test

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditTextTest.kt
@@ -57,6 +57,16 @@ class CurrencyMaterialEditTextTest {
     }
 
     @Test
+    fun disablingACalculatorTheLayoutNeverHadKeepsTheHostsEndIcon() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            currencyEditText.endIconMode = TextInputLayout.END_ICON_CLEAR_TEXT
+            currencyEditText.setCalculatorEnabled(false)
+        }
+
+        Assert.assertEquals(TextInputLayout.END_ICON_CLEAR_TEXT, currencyEditText.endIconMode)
+    }
+
+    @Test
     fun shouldSetText() {
         val samples =
             listOf(

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
@@ -20,7 +20,11 @@ import android.graphics.Rect
 import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatEditText
+import ru.pravbeseda.currencyedittext.calculator.CalculatorPopup
 import ru.pravbeseda.currencyedittext.model.CurrencyInputWatcherConfig
 import ru.pravbeseda.currencyedittext.util.firstChar
 import ru.pravbeseda.currencyedittext.util.formatMoneyValue
@@ -44,6 +48,7 @@ open class CurrencyEditText(
     private var decimalZerosPadding: Boolean = false
     private var emptyStringForZero: Boolean = true
     private var maxDecimalPlaces: Int
+    private var calculatorEnabled: Boolean = false
 
     private var onValueChanged: OnValueChanged? = null
     private var validator: ((BigDecimal) -> String?)? = null
@@ -93,6 +98,8 @@ open class CurrencyEditText(
                         getBoolean(R.styleable.CurrencyEditText_decimalZerosPadding, false)
                     emptyStringForZero =
                         getBoolean(R.styleable.CurrencyEditText_emptyStringForZero, true)
+                    calculatorEnabled =
+                        getBoolean(R.styleable.CurrencyEditText_calculatorEnabled, false)
                 } finally {
                     recycle()
                 }
@@ -105,6 +112,7 @@ open class CurrencyEditText(
         textWatcher = createTextWatcher()
         this.addTextChangedListener(textWatcher)
         text = this.text // to apply text watcher formatting
+        updateCalculatorButton()
     }
 
     fun setValue(value: BigDecimal) {
@@ -197,6 +205,51 @@ open class CurrencyEditText(
 
     fun isValidState(): Boolean = state == State.OK
 
+    /**
+     * Shows or hides the calculator button. The panel reads the field's configuration when it
+     * opens, so this changes nothing about the watcher and must not invalidate it.
+     */
+    fun setCalculatorEnabled(enabled: Boolean) {
+        calculatorEnabled = enabled
+        updateCalculatorButton()
+    }
+
+    fun isCalculatorEnabled(): Boolean = calculatorEnabled
+
+    /**
+     * Opens the calculator panel under [anchor], which is the field itself unless it sits inside a
+     * [CurrencyMaterialEditText] — there the panel hangs below the whole layout.
+     */
+    internal fun showCalculator(anchor: View) {
+        CalculatorPopup(
+            anchor = anchor,
+            decimalSeparator = getDecimalSeparator(),
+            scale = maxDecimalPlaces,
+            negativeValueAllow = negativeValueAllow,
+            initialValue = getValue(),
+            onAccept = ::setValue,
+        ).show()
+    }
+
+    private fun updateCalculatorButton() {
+        val icon =
+            if (calculatorEnabled) {
+                AppCompatResources.getDrawable(context, R.drawable.currency_edit_text_ic_calculator)
+            } else {
+                null
+            }
+        setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, icon, null)
+    }
+
+    private fun isTouchOnCalculatorButton(x: Float): Boolean {
+        val iconWidth = compoundDrawablesRelative[END_DRAWABLE]?.bounds?.width() ?: return false
+        return if (layoutDirection == LAYOUT_DIRECTION_RTL) {
+            x <= paddingLeft + iconWidth
+        } else {
+            x >= width - paddingRight - iconWidth
+        }
+    }
+
     private fun invalidateTextWatcher() {
         removeTextChangedListener(textWatcher)
         textWatcher = createTextWatcher()
@@ -253,6 +306,22 @@ open class CurrencyEditText(
         super.setText(text, type)
         getText()?.length?.let { setSelection(it) }
     }
+
+    /**
+     * The calculator button is a compound drawable rather than a view of its own, so the tap on it
+     * is recognised here, by where it lands. Everything else is ordinary text editing.
+     */
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_UP && isTouchOnCalculatorButton(event.x)) {
+            performClick()
+            showCalculator(this)
+            return true
+        }
+        return super.onTouchEvent(event)
+    }
+
+    /** Overridden only because [onTouchEvent] is: an accessibility click has to reach the view. */
+    override fun performClick(): Boolean = super.performClick()
 
     override fun onFocusChanged(
         focused: Boolean,
@@ -314,6 +383,9 @@ open class CurrencyEditText(
     }
 
     companion object {
+        /** Index of the end drawable in `compoundDrawablesRelative`. */
+        private const val END_DRAWABLE = 2
+
         /**
          * Component's state values
          */

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyEditText.kt
@@ -17,6 +17,7 @@ package ru.pravbeseda.currencyedittext
 
 import android.content.Context
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.util.AttributeSet
@@ -49,6 +50,7 @@ open class CurrencyEditText(
     private var emptyStringForZero: Boolean = true
     private var maxDecimalPlaces: Int
     private var calculatorEnabled: Boolean = false
+    private var calculatorIcon: Drawable? = null
 
     private var onValueChanged: OnValueChanged? = null
     private var validator: ((BigDecimal) -> String?)? = null
@@ -112,7 +114,7 @@ open class CurrencyEditText(
         textWatcher = createTextWatcher()
         this.addTextChangedListener(textWatcher)
         text = this.text // to apply text watcher formatting
-        updateCalculatorButton()
+        if (calculatorEnabled) updateCalculatorButton()
     }
 
     fun setValue(value: BigDecimal) {
@@ -210,6 +212,7 @@ open class CurrencyEditText(
      * opens, so this changes nothing about the watcher and must not invalidate it.
      */
     fun setCalculatorEnabled(enabled: Boolean) {
+        if (calculatorEnabled == enabled) return
         calculatorEnabled = enabled
         updateCalculatorButton()
     }
@@ -231,18 +234,32 @@ open class CurrencyEditText(
         ).show()
     }
 
+    /** The button takes the end slot only; whatever the host put in the other three stays. */
     private fun updateCalculatorButton() {
-        val icon =
+        val drawables = compoundDrawablesRelative
+        calculatorIcon =
             if (calculatorEnabled) {
                 AppCompatResources.getDrawable(context, R.drawable.currency_edit_text_ic_calculator)
             } else {
                 null
             }
-        setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, icon, null)
+        setCompoundDrawablesRelativeWithIntrinsicBounds(
+            drawables[START_DRAWABLE],
+            drawables[TOP_DRAWABLE],
+            calculatorIcon,
+            drawables[BOTTOM_DRAWABLE],
+        )
     }
 
+    /** A tap opens the panel only where the field is live and the button is the one this view drew. */
+    internal fun opensCalculatorOn(event: MotionEvent): Boolean =
+        isEnabled &&
+            calculatorEnabled &&
+            event.action == MotionEvent.ACTION_UP &&
+            isTouchOnCalculatorButton(event.x)
+
     private fun isTouchOnCalculatorButton(x: Float): Boolean {
-        val iconWidth = compoundDrawablesRelative[END_DRAWABLE]?.bounds?.width() ?: return false
+        val iconWidth = calculatorIcon?.bounds?.width() ?: return false
         return if (layoutDirection == LAYOUT_DIRECTION_RTL) {
             x <= paddingLeft + iconWidth
         } else {
@@ -312,7 +329,7 @@ open class CurrencyEditText(
      * is recognised here, by where it lands. Everything else is ordinary text editing.
      */
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        if (event.action == MotionEvent.ACTION_UP && isTouchOnCalculatorButton(event.x)) {
+        if (opensCalculatorOn(event)) {
             performClick()
             showCalculator(this)
             return true
@@ -383,8 +400,10 @@ open class CurrencyEditText(
     }
 
     companion object {
-        /** Index of the end drawable in `compoundDrawablesRelative`. */
-        private const val END_DRAWABLE = 2
+        /** Indices in `compoundDrawablesRelative`. */
+        private const val START_DRAWABLE = 0
+        private const val TOP_DRAWABLE = 1
+        private const val BOTTOM_DRAWABLE = 3
 
         /**
          * Component's state values

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
@@ -50,6 +50,7 @@ open class CurrencyMaterialEditText(
         get() = isValidState()
 
     private val editText = CurrencyEditText(context, null)
+    private var calculatorEnabled: Boolean = false
 
     init {
         var localeTag: String?
@@ -61,6 +62,7 @@ open class CurrencyMaterialEditText(
         var maxDecimalPlaces: Int
         var decimalZerosPadding: Boolean
         var emptyStringForZero: Boolean
+        var enableCalculator: Boolean
         context.theme
             .obtainStyledAttributes(
                 attrs,
@@ -87,6 +89,8 @@ open class CurrencyMaterialEditText(
                     getInt(R.styleable.CurrencyMaterialEditText_maxNumberOfDecimalPlaces, 2)
                 emptyStringForZero =
                     getBoolean(R.styleable.CurrencyMaterialEditText_emptyStringForZero, true)
+                enableCalculator =
+                    getBoolean(R.styleable.CurrencyMaterialEditText_calculatorEnabled, false)
             }
         if (!localeTag.isNullOrBlank()) {
             setLocale(getLocaleFromTag(localeTag!!))
@@ -108,6 +112,8 @@ open class CurrencyMaterialEditText(
         setDecimalZerosPadding(decimalZerosPadding)
         setEmptyStringForZero(emptyStringForZero)
         this.addView(editText)
+        // Only when asked for: the end icon belongs to the host until the calculator claims it.
+        if (enableCalculator) setCalculatorEnabled(true)
     }
 
     fun setValue(value: BigDecimal) {
@@ -161,6 +167,25 @@ open class CurrencyMaterialEditText(
     fun setEmptyStringForZero(newValue: Boolean) {
         editText.setEmptyStringForZero(newValue)
     }
+
+    /**
+     * Shows or hides the calculator button. Unlike [CurrencyEditText], which draws it as a
+     * compound drawable, the layout renders it as its own end icon and anchors the panel under the
+     * whole layout, error text included.
+     */
+    fun setCalculatorEnabled(enabled: Boolean) {
+        calculatorEnabled = enabled
+        if (enabled) {
+            endIconMode = END_ICON_CUSTOM
+            setEndIconDrawable(R.drawable.currency_edit_text_ic_calculator)
+            setEndIconContentDescription(R.string.currency_edit_text_calculator)
+            setEndIconOnClickListener { editText.showCalculator(this) }
+        } else {
+            endIconMode = END_ICON_NONE
+        }
+    }
+
+    fun isCalculatorEnabled(): Boolean = calculatorEnabled
 
     fun onValueChanged(action: (BigDecimal?, state: CurrencyEditText.Companion.State, textError: String) -> Unit) {
         editText.onValueChanged(action)

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/CurrencyMaterialEditText.kt
@@ -174,6 +174,9 @@ open class CurrencyMaterialEditText(
      * whole layout, error text included.
      */
     fun setCalculatorEnabled(enabled: Boolean) {
+        // Nothing to do when the state does not change: the end icon is the host's until the
+        // calculator claims it, and switching a calculator off that was never on must not take it.
+        if (calculatorEnabled == enabled) return
         calculatorEnabled = enabled
         if (enabled) {
             endIconMode = END_ICON_CUSTOM
@@ -181,6 +184,7 @@ open class CurrencyMaterialEditText(
             setEndIconContentDescription(R.string.currency_edit_text_calculator)
             setEndIconOnClickListener { editText.showCalculator(this) }
         } else {
+            setEndIconOnClickListener(null)
             endIconMode = END_ICON_NONE
         }
     }

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
@@ -43,3 +43,16 @@ internal enum class CalculatorKey(
     BACKSPACE('⌫'),
     CLEAR('C'),
 }
+
+/** Operators the panel prints differently from the ASCII the expression is built out of. */
+private val PRINTED_OPERATORS = mapOf('*' to '\u00d7', '/' to '\u00f7', '-' to '\u2212')
+
+/** The character the user reads in place of [this]: an operator sign, or their decimal separator. */
+internal fun Char.printed(decimalSeparator: Char): Char =
+    when {
+        this == '.' -> decimalSeparator
+        else -> PRINTED_OPERATORS[this] ?: this
+    }
+
+/** The label the panel draws on the key's button. */
+internal fun CalculatorKey.label(decimalSeparator: Char): String = symbol.printed(decimalSeparator).toString()

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPlacement.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPlacement.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+/**
+ * Where the panel hangs and how tall it may be. A [height] of `null` means it may take the height
+ * it asked for; a number is the room it has to fit into, which the panel then scrolls inside.
+ */
+internal data class CalculatorPlacement(
+    val above: Boolean,
+    val height: Int?,
+) {
+    companion object {
+        /**
+         * Puts the panel below the field where it fits there, above it where only that side has
+         * room, and on the roomier side capped to that room where neither is tall enough — a
+         * landscape screen, typically. An uncapped panel would be clipped to the space below the
+         * field and could show no keys at all.
+         */
+        fun choose(
+            spaceBelow: Int,
+            spaceAbove: Int,
+            wanted: Int,
+        ): CalculatorPlacement {
+            val above = wanted > spaceBelow && spaceAbove > spaceBelow
+            val room = if (above) spaceAbove else spaceBelow
+            return CalculatorPlacement(above = above, height = if (wanted <= room) null else room)
+        }
+    }
+}

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import android.graphics.Rect
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.PopupWindow
+import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
+import ru.pravbeseda.currencyedittext.R
+import java.math.BigDecimal
+
+/** Which key each button of the panel presses. The button's label comes from the key itself. */
+private val KEY_BUTTONS =
+    mapOf(
+        R.id.currency_calculator_key_0 to CalculatorKey.DIGIT_0,
+        R.id.currency_calculator_key_1 to CalculatorKey.DIGIT_1,
+        R.id.currency_calculator_key_2 to CalculatorKey.DIGIT_2,
+        R.id.currency_calculator_key_3 to CalculatorKey.DIGIT_3,
+        R.id.currency_calculator_key_4 to CalculatorKey.DIGIT_4,
+        R.id.currency_calculator_key_5 to CalculatorKey.DIGIT_5,
+        R.id.currency_calculator_key_6 to CalculatorKey.DIGIT_6,
+        R.id.currency_calculator_key_7 to CalculatorKey.DIGIT_7,
+        R.id.currency_calculator_key_8 to CalculatorKey.DIGIT_8,
+        R.id.currency_calculator_key_9 to CalculatorKey.DIGIT_9,
+        R.id.currency_calculator_key_decimal to CalculatorKey.DECIMAL,
+        R.id.currency_calculator_key_plus to CalculatorKey.PLUS,
+        R.id.currency_calculator_key_minus to CalculatorKey.MINUS,
+        R.id.currency_calculator_key_multiply to CalculatorKey.MULTIPLY,
+        R.id.currency_calculator_key_divide to CalculatorKey.DIVIDE,
+        R.id.currency_calculator_key_open_paren to CalculatorKey.OPEN_PAREN,
+        R.id.currency_calculator_key_close_paren to CalculatorKey.CLOSE_PAREN,
+        R.id.currency_calculator_key_sign to CalculatorKey.SIGN,
+        R.id.currency_calculator_key_backspace to CalculatorKey.BACKSPACE,
+        R.id.currency_calculator_key_clear to CalculatorKey.CLEAR,
+    )
+
+private const val ERROR_COLOR = 0xFFB00020.toInt()
+
+private const val EQUALS_LABEL = "="
+
+/**
+ * The calculator panel: the only class here that touches Android. It inflates the keys, hands each
+ * press to [CalculatorState] and, on `=`, gives the value back to the field through [onAccept].
+ *
+ * An expression that does not evaluate — incomplete, dividing by zero, or negative where the field
+ * takes no negative values — leaves the panel open in an error state and writes nothing.
+ */
+internal class CalculatorPopup(
+    private val anchor: View,
+    private val decimalSeparator: Char,
+    private val scale: Int,
+    private val negativeValueAllow: Boolean,
+    initialValue: BigDecimal,
+    private val onAccept: (BigDecimal) -> Unit,
+) {
+    private var state = CalculatorState.seededWith(initialValue)
+    private var defaultTextColor: Int = 0
+    private lateinit var expressionView: TextView
+    private lateinit var window: PopupWindow
+
+    fun show() {
+        val content =
+            LayoutInflater
+                .from(anchor.context)
+                .inflate(R.layout.currency_calculator_panel, FrameLayout(anchor.context), false)
+        bindKeys(content)
+        expressionView = content.findViewById(R.id.currency_calculator_expression)
+        defaultTextColor = expressionView.textColors.defaultColor
+        render(failed = false)
+        window =
+            PopupWindow(content, panelWidth(), ViewGroup.LayoutParams.WRAP_CONTENT, true).apply {
+                setBackgroundDrawable(
+                    AppCompatResources.getDrawable(
+                        anchor.context,
+                        R.drawable.currency_calculator_panel_background,
+                    ),
+                )
+                isOutsideTouchable = true
+                elevation = anchor.resources.displayMetrics.density * POPUP_ELEVATION_DP
+            }
+        showAnchored(content)
+    }
+
+    /**
+     * Hangs the panel on whichever side of the field has room for it, and caps its height to that
+     * room where neither side is tall enough — a landscape screen, typically. The panel scrolls, so
+     * a capped one is cramped rather than unusable, while an uncapped one would be clipped to the
+     * space below the field and could show no keys at all.
+     */
+    private fun showAnchored(content: View) {
+        val visible = Rect().also { anchor.getWindowVisibleDisplayFrame(it) }
+        val anchorTop = IntArray(2).also { anchor.getLocationOnScreen(it) }[1]
+        val below = visible.bottom - (anchorTop + anchor.height)
+        val above = anchorTop - visible.top
+        val wanted = measureHeight(content)
+
+        val dropDown = wanted <= below || below >= above
+        val room = if (dropDown) below else above
+        window.height = if (wanted <= room) ViewGroup.LayoutParams.WRAP_CONTENT else room
+        if (dropDown) {
+            window.showAsDropDown(anchor)
+        } else {
+            window.showAsDropDown(anchor, 0, -(anchor.height + minOf(wanted, room)))
+        }
+    }
+
+    private fun measureHeight(content: View): Int {
+        val width = panelWidth()
+        val widthSpec =
+            if (width > 0) {
+                View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY)
+            } else {
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+            }
+        content.measure(widthSpec, View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED))
+        return content.measuredHeight
+    }
+
+    /** The panel is as wide as the field it belongs to, unless that field is not laid out yet. */
+    private fun panelWidth(): Int = if (anchor.width > 0) anchor.width else ViewGroup.LayoutParams.WRAP_CONTENT
+
+    private fun bindKeys(content: View) {
+        KEY_BUTTONS.forEach { (id, key) ->
+            content.findViewById<Button>(id).apply {
+                text = key.label(decimalSeparator)
+                // Kept visible but dead, so the panel does not change shape between fields.
+                isEnabled = key != CalculatorKey.SIGN || negativeValueAllow
+                setOnClickListener { press(key) }
+            }
+        }
+        content.findViewById<Button>(R.id.currency_calculator_key_equals).apply {
+            text = EQUALS_LABEL
+            setOnClickListener { accept() }
+        }
+    }
+
+    private fun press(key: CalculatorKey) {
+        state = state.press(key)
+        render(failed = false)
+    }
+
+    private fun accept() {
+        when (val result = state.result(scale, negativeValueAllow)) {
+            is EvalResult.Success -> {
+                window.dismiss()
+                onAccept(result.value)
+            }
+
+            EvalResult.Failure -> {
+                render(failed = true)
+            }
+        }
+    }
+
+    private fun render(failed: Boolean) {
+        expressionView.text = state.display(decimalSeparator)
+        expressionView.setTextColor(if (failed) ERROR_COLOR else defaultTextColor)
+    }
+
+    private companion object {
+        const val POPUP_ELEVATION_DP = 8f
+    }
+}

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
@@ -99,26 +99,23 @@ internal class CalculatorPopup(
         showAnchored(content)
     }
 
-    /**
-     * Hangs the panel on whichever side of the field has room for it, and caps its height to that
-     * room where neither side is tall enough — a landscape screen, typically. The panel scrolls, so
-     * a capped one is cramped rather than unusable, while an uncapped one would be clipped to the
-     * space below the field and could show no keys at all.
-     */
+    /** Measures the panel, asks [CalculatorPlacement] where it goes, and shows it there. */
     private fun showAnchored(content: View) {
         val visible = Rect().also { anchor.getWindowVisibleDisplayFrame(it) }
         val anchorTop = IntArray(2).also { anchor.getLocationOnScreen(it) }[1]
-        val below = visible.bottom - (anchorTop + anchor.height)
-        val above = anchorTop - visible.top
         val wanted = measureHeight(content)
+        val placement =
+            CalculatorPlacement.choose(
+                spaceBelow = visible.bottom - (anchorTop + anchor.height),
+                spaceAbove = anchorTop - visible.top,
+                wanted = wanted,
+            )
 
-        val dropDown = wanted <= below || below >= above
-        val room = if (dropDown) below else above
-        window.height = if (wanted <= room) ViewGroup.LayoutParams.WRAP_CONTENT else room
-        if (dropDown) {
-            window.showAsDropDown(anchor)
+        window.height = placement.height ?: ViewGroup.LayoutParams.WRAP_CONTENT
+        if (placement.above) {
+            window.showAsDropDown(anchor, 0, -(anchor.height + (placement.height ?: wanted)))
         } else {
-            window.showAsDropDown(anchor, 0, -(anchor.height + minOf(wanted, room)))
+            window.showAsDropDown(anchor)
         }
     }
 

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorState.kt
@@ -64,7 +64,21 @@ internal data class CalculatorState(
             else -> appendDigit(key.symbol)
         }
 
-    fun result(scale: Int): EvalResult = ExpressionEvaluator.evaluate(expression, scale)
+    /**
+     * The value of the expression, or [EvalResult.Failure] when it is incomplete, divides by zero,
+     * or comes out negative in a field that takes no negative values.
+     */
+    fun result(
+        scale: Int,
+        negativeValueAllow: Boolean = true,
+    ): EvalResult {
+        val evaluated = ExpressionEvaluator.evaluate(expression, scale)
+        val refused = !negativeValueAllow && evaluated is EvalResult.Success && evaluated.value.signum() < 0
+        return if (refused) EvalResult.Failure else evaluated
+    }
+
+    /** The expression as the user reads it: their decimal separator, and the printed operators. */
+    fun display(decimalSeparator: Char): String = expression.map { it.printed(decimalSeparator) }.joinToString("")
 
     private val lastChar: Char? get() = expression.lastOrNull()
 

--- a/library/src/main/res-public/values/attrs.xml
+++ b/library/src/main/res-public/values/attrs.xml
@@ -9,6 +9,7 @@
     <attr name="maxNumberOfDecimalPlaces" format="integer" />
     <attr name="decimalZerosPadding" format="boolean" />
     <attr name="emptyStringForZero" format="boolean" />
+    <attr name="calculatorEnabled" format="boolean" />
 
     <declare-styleable name="CurrencyEditText">
         <attr name="currencySymbol" />
@@ -20,6 +21,7 @@
         <attr name="decimalZerosPadding" />
         <attr name="maxNumberOfDecimalPlaces" />
         <attr name="emptyStringForZero" />
+        <attr name="calculatorEnabled" />
     </declare-styleable>
     <declare-styleable name="CurrencyMaterialEditText">
         <attr name="text" format="string" />
@@ -33,5 +35,6 @@
         <attr name="decimalZerosPadding" />
         <attr name="maxNumberOfDecimalPlaces" />
         <attr name="emptyStringForZero" />
+        <attr name="calculatorEnabled" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/drawable/currency_calculator_panel_background.xml
+++ b/library/src/main/res/drawable/currency_calculator_panel_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2022-2023 Alexander Ivanov
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The popup's own background: a PopupWindow needs one to dismiss on an outside tap. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?android:attr/colorBackground" />
+    <corners android:radius="8dp" />
+</shape>

--- a/library/src/main/res/drawable/currency_edit_text_ic_calculator.xml
+++ b/library/src/main/res/drawable/currency_edit_text_ic_calculator.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2022-2023 Alexander Ivanov
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FF000000"
+        android:fillType="evenOdd"
+        android:pathData="M5,3h14a2,2 0 0 1 2,2v14a2,2 0 0 1 -2,2H5a2,2 0 0 1 -2,-2V5a2,2 0 0 1 2,-2zM5,5v3h14V5zM6,10v2h2v-2zM10,10v2h2v-2zM14,10v2h2v-2zM6,14v2h2v-2zM10,14v2h2v-2zM14,14v2h2v-2z" />
+</vector>

--- a/library/src/main/res/layout/currency_calculator_panel.xml
+++ b/library/src/main/res/layout/currency_calculator_panel.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2022-2023 Alexander Ivanov
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Key labels are set from CalculatorKey, so a key always shows what it does. -->
+<!-- Scrollable so that a screen too short for the whole panel shows a usable part of it. -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="8dp">
+
+        <TextView
+            android:id="@+id/currency_calculator_expression"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="start"
+            android:gravity="end"
+            android:maxLines="1"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:textSize="20sp" />
+
+        <GridLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="4">
+
+            <Button
+                android:id="@+id/currency_calculator_key_clear"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_open_paren"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_close_paren"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_backspace"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_7"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_8"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_9"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_divide"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_4"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_5"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_6"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_multiply"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_1"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_2"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_3"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_minus"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_sign"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_0"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_decimal"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_plus"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/currency_calculator_key_equals"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnSpan="4"
+                android:layout_columnWeight="1"
+                android:layout_gravity="fill_horizontal"
+                android:minHeight="48dp"
+                android:minWidth="0dp"
+                android:textSize="18sp" />
+
+        </GridLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="currency_edit_text_calculator">Calculator</string>
 </resources>

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKeyTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKeyTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CalculatorKeyTest {
+    @Test
+    fun `a key is drawn with the printed operator, not the one it appends`() {
+        assertEquals("×", CalculatorKey.MULTIPLY.label('.'))
+        assertEquals("÷", CalculatorKey.DIVIDE.label('.'))
+        assertEquals("−", CalculatorKey.MINUS.label('.'))
+    }
+
+    @Test
+    fun `the decimal key is drawn with the field's separator`() {
+        assertEquals(",", CalculatorKey.DECIMAL.label(','))
+        assertEquals(".", CalculatorKey.DECIMAL.label('.'))
+    }
+
+    @Test
+    fun `every other key is drawn with its own symbol`() {
+        assertEquals("7", CalculatorKey.DIGIT_7.label(','))
+        assertEquals("(", CalculatorKey.OPEN_PAREN.label(','))
+        assertEquals("C", CalculatorKey.CLEAR.label(','))
+    }
+}

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPlacementTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPlacementTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CalculatorPlacementTest {
+    @Test
+    fun `a panel that fits below the field hangs below it, at its full height`() {
+        assertEquals(
+            CalculatorPlacement(above = false, height = null),
+            CalculatorPlacement.choose(spaceBelow = 800, spaceAbove = 300, wanted = 700),
+        )
+    }
+
+    @Test
+    fun `a panel too tall for the space below flips above the field`() {
+        assertEquals(
+            CalculatorPlacement(above = true, height = null),
+            CalculatorPlacement.choose(spaceBelow = 200, spaceAbove = 900, wanted = 700),
+        )
+    }
+
+    @Test
+    fun `a panel that fits neither side is capped to the roomier one`() {
+        assertEquals(
+            CalculatorPlacement(above = true, height = 500),
+            CalculatorPlacement.choose(spaceBelow = 200, spaceAbove = 500, wanted = 700),
+        )
+        assertEquals(
+            CalculatorPlacement(above = false, height = 400),
+            CalculatorPlacement.choose(spaceBelow = 400, spaceAbove = 300, wanted = 700),
+        )
+    }
+
+    @Test
+    fun `equal room hangs the panel below, where a dropdown belongs`() {
+        assertEquals(
+            CalculatorPlacement(above = false, height = 300),
+            CalculatorPlacement.choose(spaceBelow = 300, spaceAbove = 300, wanted = 700),
+        )
+    }
+}

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorStateTest.kt
@@ -184,6 +184,26 @@ class CalculatorStateTest {
         assertEquals(EvalResult.Failure, result(""))
     }
 
+    @Test
+    fun `a negative result is refused when the field allows no negative values`() {
+        assertEquals(EvalResult.Success(BigDecimal("-5.00")), CalculatorState("1-6").result(scale = 2))
+        assertEquals(
+            EvalResult.Failure,
+            CalculatorState("1-6").result(scale = 2, negativeValueAllow = false),
+        )
+        assertEquals(
+            EvalResult.Success(BigDecimal("5.00")),
+            CalculatorState("6-1").result(scale = 2, negativeValueAllow = false),
+        )
+    }
+
+    @Test
+    fun `the expression is displayed with the field's separator and the printed operators`() {
+        assertEquals("1234,5\u00d72\u00f74", CalculatorState("1234.5*2/4").display(','))
+        assertEquals("1234.5\u00d72", CalculatorState("1234.5*2").display('.'))
+        assertEquals("\u22125+(\u22123)", CalculatorState("-5+(-3)").display('.'))
+    }
+
     private fun press(vararg keys: CalculatorKey): String = keys.fold(CalculatorState()) { state, key -> state.press(key) }.expression
 
     private fun result(expression: String): EvalResult = CalculatorState(expression).result(scale = 2)

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -56,6 +56,7 @@
             app:maxNumberOfDecimalPlaces="2"
             app:decimalZerosPadding="false"
             app:localeTag="da-DK"
+            app:calculatorEnabled="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textView"
@@ -92,6 +93,7 @@
             android:theme="@style/CustomThemeEditText"
             app:negativeValueAllow="true"
             app:errorEnabled="true"
+            app:calculatorEnabled="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/button" />


### PR DESCRIPTION
Second half of `.github/tasks/calculator-input-panel.md` — the panel, the button and the attribute. PR 1 (#36) added the evaluator and the key state machine.

## What it does

A calculator button at the end of the field, off by default. It opens a panel seeded with the field's current value; `=` writes the result back through `setValue`, so grouping, currency prefix and padding come from `CurrencyInputWatcher` as usual. The system keyboard is not replaced. An expression that is incomplete, divides by zero, or comes out negative in a field with `negativeValueAllow="false"` leaves the field untouched and shows an error state.

`CalculatorPopup` is the only class of the calculator package that touches Android. Key semantics, the arithmetic and the expression line stay in `CalculatorState` and `ExpressionEvaluator`, which `src/test` covers.

## Public API change

Additive only, no existing signature changes:

- `calculatorEnabled` XML attribute on both views (default `false`)
- `setCalculatorEnabled(Boolean)` and `isCalculatorEnabled(): Boolean` on both views
- `CurrencyEditText.onTouchEvent` and `performClick`: overrides of `View` methods, in the ABI dump for that reason. `onTouchEvent` recognises the tap on the compound drawable; `performClick` is what lint's `ClickableViewAccessibility` requires of a view that overrides it.

`updateKotlinAbi` diff is in the same commit.

## Departures from the plan, worth a look

1. `CurrencyMaterialEditText` does **not** delegate `calculatorEnabled` to the inner view, as the plan's step 5 suggested: the layout draws the button through `END_ICON_CUSTOM`, and a delegating setter would make the inner `CurrencyEditText` draw a second one as a compound drawable. It keeps its own flag and claims the end icon only when asked, so a host's own `endIconMode` survives.
2. `CalculatorPopup` is excluded from the Kover filter. It cannot be reached from `src/test`, exactly like the two Views, and an unfiltered figure would report the size of the panel rather than the quality of the tests. Coverage is 88.6% against the unchanged `minBound(80)`.
3. The panel hangs on whichever side of the field has room and caps its height to that room, scrolling inside it. This is the plan's stated risk: in landscape the popup was clipped to the space below the field and showed no keys at all. Verified on the emulator in both orientations.
4. `app:calculatorEnabled="true"` is set on both sample fields — the feature could not be checked by hand otherwise.

## Also here

`fix: rename the instrumented test that cannot be dexed (#39)` — a backtick test name with spaces made `:library:dexBuilderDebugAndroidTest` fail for the whole instrumented suite, so the `instrumented` job of `ci.yml` has been red on `main` since #34. Without it none of the instrumented tests below could run. Fixes #39.

## Tests

- `CalculatorStateTest`, `CalculatorKeyTest`: the negative-result policy, the expression line and the key labels, written before the implementation and watched fail.
- Instrumented tests in both views: `calculatorEnabled` defaults to `false`, and enabling it shows the button. 14/14 green on an emulator.
- `./gradlew build` green locally.
- By hand on the emulator: `1123,48 + 100 =` writes `$ 1.223,48` into the field and fires `onValueChanged`; the panel flips above the field in landscape.