### PR TITLE
chore: pin the library's Kotlin language and api version to 2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ Updates arrive through Renovate, configured in `renovate.json5`: weekly, patch r
 automerged, minor and major read by a person, androidx grouped, the toolchain never automerged.
 The file only configures the bot — the GitHub App itself is installed on the repository by hand.
 
+The Kotlin language and api versions are pinned to 2.1 in `library/build.gradle`, and
+`kotlin.stdlib.default.dependency=false` in `gradle.properties` hands the stdlib version to
+the catalog's `kotlinStdlib = "2.1.0"`, declared by both modules. Together they are what
+lets a consumer on Kotlin 2.1 use the published artifact: the pin alone stamps `mv=[2,1,0]`
+on the library's own classes, but the POM would still carry the plugin's `kotlin-stdlib`
+2.4.10 and stop that consumer on the stdlib instead. Both halves are needed; changing either
+one alone re-breaks it.
+
 `androidx.core` is held at 1.17.0 on purpose: 1.18.0 and above require Android Gradle plugin
 9.1.0. Renovate will keep offering the newer one; the pull request waits for the AGP upgrade.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ implementation 'ru.pravbeseda:CurrencyEditText:<insert-latest-version-here>'
 
 Requires `minSdk 24` (Android 7.0). Releases up to 1.1.1 support `minSdk 19`.
 
-The artifact is compiled against Kotlin 2.1, so it can be consumed by Kotlin 2.1 and
-newer. Release 2.0.0 was built with Kotlin 2.4 metadata and needs a 2.4 compiler.
+The artifact carries Kotlin 2.1 metadata and declares `kotlin-stdlib:2.1.0`, so a project
+on Kotlin 2.1 or newer can consume it with nothing special in its own build; a newer
+consumer keeps its own stdlib. Release 2.0.0 carries Kotlin 2.4 metadata and needs a 2.4
+compiler.
 
 For versions, kindly head over to
 the [releases page](https://github.com/pravbeseda/CurrencyEditText/releases)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ implementation 'ru.pravbeseda:CurrencyEditText:<insert-latest-version-here>'
 
 Requires `minSdk 24` (Android 7.0). Releases up to 1.1.1 support `minSdk 19`.
 
+The artifact is compiled against Kotlin 2.1, so it can be consumed by Kotlin 2.1 and
+newer. Release 2.0.0 was built with Kotlin 2.4 metadata and needs a 2.4 compiler.
+
 For versions, kindly head over to
 the [releases page](https://github.com/pravbeseda/CurrencyEditText/releases)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,12 @@ android.useAndroidX=true
 android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# The Kotlin Gradle plugin otherwise adds kotlin-stdlib at its own version, and that
+# version is what the published POM declares. At 2.4.10 the stdlib carries mv=[2,4,0],
+# so a consumer on Kotlin 2.1 was stopped by the stdlib even though this library's own
+# classes are stamped mv=[2,1,0]. With the default off, both modules declare the stdlib
+# themselves at the version in the catalog. Project-wide, hence :sample declaring it too.
+kotlin.stdlib.default.dependency=false
 # Maven Deployment Variables
 SONATYPE_HOST=CENTRAL_PORTAL
 RELEASE_SIGNING_ENABLED=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,11 @@
 # --- toolchain -------------------------------------------------------------
 agp = "8.13.0"
 kotlin = "2.4.10"
+# Deliberately behind `kotlin`, and not a mistake Renovate should quietly fix: this is the
+# stdlib version the published POM declares, and it is the floor a consumer's own Kotlin
+# raises by conflict resolution. Held at the lowest version that speaks the language version
+# the library is compiled with, so a consumer on Kotlin 2.1 resolves a stdlib it can read.
+kotlinStdlib = "2.1.0"
 mavenPublish = "0.34.0"
 
 # --- quality gates ---------------------------------------------------------
@@ -46,6 +51,7 @@ androidx-test-ext-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "testRules" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "testRunner" }
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinStdlib" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,6 +36,16 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        // The metadata version of the published classes follows the language
+        // version, so building with the compiler's own 2.4 stamps mv=[2,4,0] and
+        // every consumer still on Kotlin 2.1 or 2.2 is met with "class file was
+        // compiled by a newer Kotlin compiler". Pinning both to 2.1 stamps
+        // mv=[2,1,0] instead, which every compiler from 2.1 up can read. The api
+        // version keeps the source honest about it: no stdlib member newer than
+        // 2.1 can slip into the artifact. kotlinc warns that 2.1 is deprecated;
+        // the warning is the cost of the wider reach and fails nothing.
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1
+        apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1
     }
 
     // The public API gate, and the only one here that looks at the artifact's

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation libs.androidx.appcompat
 
     api libs.material
+    api libs.kotlin.stdlib
 
     testImplementation libs.junit
     testImplementation libs.androidx.test.core.ktx

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,6 +33,9 @@ kotlin {
 
 dependencies {
     implementation project(':library')
+    // kotlin.stdlib.default.dependency is off project-wide — see gradle.properties — so the
+    // demo declares the stdlib itself. Nothing here needs a newer one than the library's.
+    implementation libs.kotlin.stdlib
     implementation libs.androidx.core.ktx
     implementation libs.material
     implementation libs.androidx.appcompat


### PR DESCRIPTION
## What

`:library` now compiles with `languageVersion = 2.1` and `apiVersion = 2.1`.

## Why

The Kotlin metadata version stamped into the published classes follows the language
version. Built with the compiler's own 2.4, `CurrencyEditText.class` carries
`mv=[2,4,0]`, and a consumer on Kotlin 2.1 or 2.2 gets *"class file was compiled by a
newer Kotlin compiler"*. With the pin the same class carries `mv=[2,1,0]`, readable by
every compiler from 2.1 up. `apiVersion` keeps the source honest about it: no stdlib
member newer than 2.1 can slip into the artifact.

Verified on the bytecode, `javap -v` on the release variant:

| | metadata version |
|---|---|
| before | `mv=[2,4,0]` |
| after | `mv=[2,1,0]` |

## Consumer-visible change

This widens what can consume the artifact; it does not narrow it. `library/api/library.api`
is unchanged — the metadata version is not part of the ABI dump — so no `updateKotlinAbi`
is needed.

## Trade-off

`kotlinc` prints `Language version 2.1 is deprecated and its support will be removed in a
future version of Kotlin`. It fails nothing: `warningsAsErrors` is configured for Android
Lint only, and `allWarningsAsErrors` is not set for Kotlin. The next major Kotlin line will
force the choice again.

## Tests

No tests, because this is a build-script change — the exception CLAUDE.md names alongside
pure renames and doc edits. The effect is verified by inspecting the emitted metadata
version rather than by a unit test, which cannot observe it.

## Checks

- `./gradlew build` — green
- `./gradlew :library:checkKotlinAbi` — green, dump unchanged
- Kover: 88.79% against the floor of 80
