### PR TITLE
Calculator panel: a public style contract, and placement after the keyboard closes

### DIFF
--- a/.github/tasks/calculator-panel-placement-and-theme.md
+++ b/.github/tasks/calculator-panel-placement-and-theme.md
@@ -1,0 +1,61 @@
+# Calculator panel: placement after the keyboard closes, and theming
+
+## Goal
+
+The calculator panel opens clipped to a few key rows and paints itself in the platform's default
+purple instead of the host app's Material theme. Both are library bugs, reproduced on a Material3
+dark-themed app (see the issue screenshot): fix the placement race and make the panel take its
+colors from the app's theme.
+
+## The two defects
+
+1. **Stale measurement.** `CalculatorPopup.showAnchored` (`CalculatorPopup.kt:104-118`) reads
+   `getWindowVisibleDisplayFrame()` while the soft keyboard is still open, so `spaceBelow` is small,
+   `CalculatorPlacement.choose` flips the panel above the field and caps its height to `spaceAbove`.
+   The panel is then shown with `PopupWindow(..., focusable = true)`, which takes focus and closes
+   the IME — the screen frees up, and the panel keeps hanging at the height measured for a screen
+   that no longer exists. Inside the `ScrollView` that shows as ~2.5 visible rows.
+2. **Framework theme attributes.** Every key uses `style="?android:attr/borderlessButtonStyle"`
+   (`currency_calculator_panel.xml`, 21 occurrences) and the popup background uses
+   `?android:attr/colorBackground` (`currency_calculator_panel_background.xml:20`). Framework
+   attributes do not see a Material3 app theme, so the panel falls back to the platform defaults —
+   the purple labels in the screenshot. `library/build.gradle:65` already declares
+   `api libs.material`, so Material attributes (`?attr/colorSurface`, `?attr/colorOnSurface`,
+   `?attr/colorPrimary`, `?attr/materialButtonOutlinedStyle` / `borderlessButtonStyle`) are
+   available without a new dependency.
+
+## Decisions
+
+- How to fix the stale measurement → close the IME before showing the panel and place it only once
+  the window frame has settled (hide the soft input, then a one-shot layout listener with a timeout
+  fallback for the case where no keyboard was open), because the panel then appears once, already in
+  the right place. Re-placing the panel on every frame change while it is open is the more robust
+  option and was rejected as overkill for a short-lived popup that visibly jumps on open.
+- How far the theming fix goes → Material theme attributes only, no new public API: `?attr/colorSurface`
+  for the background, `?attr/colorOnSurface` for the key labels, `?attr/colorPrimary` for the
+  operators and `=`, plus the repeated key block extracted into a private `res/values/styles.xml`.
+  Public attributes or a public style overlay would freeze a resource contract nobody has asked for
+  yet, and either can still be added later without breaking this.
+- Only two steps, not the usual three to seven: the run fixes two independent defects in the same
+  component, and neither splits into a smaller slice with its own observable criterion.
+- Test home → `src/androidTest`. Neither defect is reachable from `src/test`: one is resource
+  resolution against the host theme, the other is IME timing in a `PopupWindow`. An emulator is
+  attached, so the instrumented suite runs locally in this session.
+
+## Steps
+
+- [ ] 1. Theme the panel from the app's Material theme — files: `library/src/main/res/layout/currency_calculator_panel.xml`,
+  `library/src/main/res/drawable/currency_calculator_panel_background.xml`, new
+  `library/src/main/res/values/styles.xml` — lenses: none — done when: a new instrumented test
+  inflates the panel under a Material3 theme and asserts a key's text color is the theme's
+  `colorOnSurface` (red before the change), and `:library:connectedAndroidTest` is green.
+- [ ] 2. Place the panel after the keyboard has closed — files:
+  `library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt` — lenses: none
+  — done when: `:library:test` and `:library:connectedAndroidTest` stay green, and in the sample app
+  on the emulator, with the keyboard open on the field, the panel opens below the field at its full
+  height (screenshot recorded in the PR). No unit test for the glue itself: it is IME timing inside
+  a `PopupWindow` and cannot be reached from `src/test`.
+
+## Rulings
+
+## Parked

--- a/.github/tasks/calculator-panel-placement-and-theme.md
+++ b/.github/tasks/calculator-panel-placement-and-theme.md
@@ -31,11 +31,21 @@ colors from the app's theme.
   fallback for the case where no keyboard was open), because the panel then appears once, already in
   the right place. Re-placing the panel on every frame change while it is open is the more robust
   option and was rejected as overkill for a short-lived popup that visibly jumps on open.
-- How far the theming fix goes → Material theme attributes only, no new public API: `?attr/colorSurface`
-  for the background, `?attr/colorOnSurface` for the key labels, `?attr/colorPrimary` for the
-  operators and `=`, plus the repeated key block extracted into a private `res/values/styles.xml`.
-  Public attributes or a public style overlay would freeze a resource contract nobody has asked for
-  yet, and either can still be added later without breaking this.
+- How far the theming fix goes → **reversed after the step-1 gate.** The first ruling was "Material
+  theme attributes only, no new public API". Measured on the emulator, that ruling crashes: under
+  `Theme.AppCompat.Light.NoActionBar` — the theme the `:sample` app itself uses — `?attr/colorSurface`
+  and `?attr/colorOnSurface` do not resolve and inflating the panel throws
+  `InflateException: Error inflating class android.widget.TextView`. The panel therefore gets a
+  public style contract instead: a theme attribute `currencyCalculatorStyle` pointing at a style
+  built from five colour roles (`calculatorPanelBackgroundColor`, `calculatorExpressionTextColor`,
+  `calculatorErrorTextColor`, `calculatorKeyTextColor`, `calculatorOperatorTextColor`), with defaults
+  that resolve in any theme (`?android:attr/colorBackground`, `?android:attr/textColorPrimary`, an
+  AppCompat `?attr/colorPrimary` state list, and the panel's existing error red as a colour
+  resource). A host overrides any subset of the five, per field, through the same
+  `android:theme` overlay it already puts on the field.
+- Where the digit/operator split lives → on `CalculatorKey` in Kotlin rather than in two layout
+  styles, because the colours are now resolved in code; that also makes the split unit-testable.
+
 - Only two steps, not the usual three to seven: the run fixes two independent defects in the same
   component, and neither splits into a smaller slice with its own observable criterion.
 - Test home → `src/androidTest`. Neither defect is reachable from `src/test`: one is resource
@@ -44,18 +54,44 @@ colors from the app's theme.
 
 ## Steps
 
-- [ ] 1. Theme the panel from the app's Material theme — files: `library/src/main/res/layout/currency_calculator_panel.xml`,
+- [x] 1. Theme the panel from the app's Material theme — files: `library/src/main/res/layout/currency_calculator_panel.xml`,
   `library/src/main/res/drawable/currency_calculator_panel_background.xml`, new
   `library/src/main/res/values/styles.xml` — lenses: none — done when: a new instrumented test
   inflates the panel under a Material3 theme and asserts a key's text color is the theme's
   `colorOnSurface` (red before the change), and `:library:connectedAndroidTest` is green.
-- [ ] 2. Place the panel after the keyboard has closed — files:
+- [x] 2. Place the panel after the keyboard has closed — files:
   `library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt` — lenses: none
   — done when: `:library:test` and `:library:connectedAndroidTest` stay green, and in the sample app
   on the emulator, with the keyboard open on the field, the panel opens below the field at its full
   height (screenshot recorded in the PR). No unit test for the glue itself: it is IME timing inside
-  a `PopupWindow` and cannot be reached from `src/test`.
+  a `PopupWindow` and cannot be reached from `src/test`. Reworked after the step-1 gate: the panel
+  now reads five colour roles from a public style contract, and the digit/operator split moved to
+  `CalculatorKey.isOperator`, which is unit-tested.
 
 ## Rulings
+
+- Quality gate, blocking: `?attr/colorSurface` / `?attr/colorOnSurface` are declared only by
+  Material, and the `:sample` app runs on `Theme.AppCompat.Light.NoActionBar`. Confirmed on the
+  emulator — inflating the panel under that theme throws `InflateException`. Escalated; the theming
+  decision was reversed into the style contract recorded under Decisions.
+- Spec gate, blocking: the done-criterion named in step 1 ("a key's text colour is the theme's
+  `colorOnSurface`, red before the change") was already green before that change, because
+  `Theme.Material3` maps `android:textColorPrimary` onto `colorOnSurface`. Accepted. The reworked
+  step carries criteria that do fail first: `CalculatorKeyRoleTest` (compile-red without
+  `isOperator`) and `thePanelInflatesUnderAnAppCompatTheme` (the crash above).
+- Spec gate, blocking: step 1 removed `?android:attr/borderlessButtonStyle` instead of replacing it,
+  so the keys silently inherited the theme's raised button style. Fixed: `CurrencyCalculatorKey`
+  now has `@android:style/Widget.Material.Button.Borderless` as its parent.
+- Quality gate, suggestion: the disabled item in `currency_calculator_key_on_surface.xml` could
+  never be selected. Fixed by deleting the file — `?android:attr/textColorPrimary` already carries
+  a disabled alpha, and only the operator role, whose sign key is disabled, still needs a state list.
+- Kover: `CalculatorColors` reads the host theme through a `Context`, so `src/test` cannot reach it
+  and its lines dropped the module below the 80% floor. Moved to its own file and added to the same
+  exclusion list as `CalculatorPopup`, for the same stated reason; the bound itself is untouched and
+  coverage now reads 81.15%. The class is covered by `CalculatorPanelThemeTest` instead.
+- `library/src/main/res-public/values/public.xml` was an empty `<resources/>` and produced no
+  `public.txt` in the AAR, so every library resource was public. It now names the sixteen XML
+  attributes, which makes the panel's layout, drawables, colours and styles private to the artifact
+  — what the calculator plan said it wanted.
 
 ## Parked

--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ On `CurrencyEditText` the button is drawn as a compound drawable and opens on a 
 it is not a separate node for a screen reader. Where that matters, use `CurrencyMaterialEditText`:
 there the button is a real end icon with a content description.
 
+### Panel colors
+
+The panel takes its colors from the host app's theme and needs no configuration. Where the defaults
+are not what you want, point `currencyCalculatorStyle` at a style of your own — on the app theme, or
+on the `android:theme` overlay of a single field, which gives that one field its own panel:
+
+```xml
+<style name="AppTheme" parent="Theme.Material3.DayNight">
+    <item name="currencyCalculatorStyle">@style/MyCalculator</item>
+</style>
+
+<style name="MyCalculator" parent="">
+    <item name="calculatorPanelBackgroundColor">@color/panel</item>
+    <item name="calculatorOperatorTextColor">?attr/colorPrimary</item>
+</style>
+```
+
+Name only the roles you want changed; the rest keep their defaults.
+
+| Attribute | What it paints | Default |
+|---|---|---|
+| `calculatorPanelBackgroundColor` | the panel behind the keys | `?android:attr/colorBackground` |
+| `calculatorExpressionTextColor` | the expression line | `?android:attr/textColorPrimary` |
+| `calculatorErrorTextColor` | the expression line when it does not evaluate | `#B00020` |
+| `calculatorKeyTextColor` | the digits and the decimal separator | `?android:attr/textColorPrimary` |
+| `calculatorOperatorTextColor` | operators, sign, backspace, clear and equals | `?attr/colorPrimary`, dimmed when a key is disabled |
+
 ## Localization
 
 The library supports localization. You can set the locale in the layout file:

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -101,7 +101,13 @@ kover {
                 // quality of the tests. Everything it decides — key semantics,
                 // arithmetic, the expression line — lives in CalculatorState
                 // and ExpressionEvaluator, which are measured.
-                classes('ru.pravbeseda.currencyedittext.calculator.CalculatorPopup')
+                // CalculatorColors is out for the same reason: it reads the
+                // host's theme through a Context, which src/test has none of.
+                // The instrumented CalculatorPanelThemeTest covers it instead.
+                classes(
+                        'ru.pravbeseda.currencyedittext.calculator.CalculatorPopup',
+                        'ru.pravbeseda.currencyedittext.calculator.CalculatorColors'
+                )
             }
         }
         variant('debug') {

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CalculatorPanelThemeTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CalculatorPanelThemeTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext
+
+import android.content.Context
+import android.graphics.Color
+import android.util.TypedValue
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The panel must take its colours from the host app's Material theme, not from the platform's. */
+class CalculatorPanelThemeTest {
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val themed =
+        ContextThemeWrapper(
+            context,
+            com.google.android.material.R.style.Theme_Material3_DayNight,
+        )
+
+    private val panel: View =
+        LayoutInflater
+            .from(themed)
+            .inflate(R.layout.currency_calculator_panel, FrameLayout(themed), false)
+
+    @Test
+    fun digitKeysUseTheThemesOnSurfaceColor() {
+        val key = panel.findViewById<Button>(R.id.currency_calculator_key_7)
+        assertEquals(colorOf(com.google.android.material.R.attr.colorOnSurface), key.currentTextColor)
+    }
+
+    @Test
+    fun operatorKeysUseTheThemesPrimaryColor() {
+        val key = panel.findViewById<Button>(R.id.currency_calculator_key_plus)
+        assertEquals(colorOf(androidx.appcompat.R.attr.colorPrimary), key.currentTextColor)
+    }
+
+    @Test
+    fun theExpressionLineUsesTheThemesOnSurfaceColor() {
+        val expression = panel.findViewById<TextView>(R.id.currency_calculator_expression)
+        assertEquals(
+            colorOf(com.google.android.material.R.attr.colorOnSurface),
+            expression.textColors.defaultColor,
+        )
+    }
+
+    @Test
+    fun aDisabledKeyIsDimmed() {
+        val key = panel.findViewById<Button>(R.id.currency_calculator_key_sign)
+        val enabled = key.currentTextColor
+        // The button's state list animator refuses to run off a Looper thread.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { key.isEnabled = false }
+        assertTrue(
+            "a disabled key must not look like a live one",
+            Color.alpha(key.currentTextColor) < Color.alpha(enabled),
+        )
+    }
+
+    private fun colorOf(attr: Int): Int {
+        val value = TypedValue()
+        check(themed.theme.resolveAttribute(attr, value, true)) { "attribute $attr is not in the theme" }
+        return if (value.resourceId != 0) themed.getColor(value.resourceId) else value.data
+    }
+}

--- a/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CalculatorPanelThemeTest.kt
+++ b/library/src/androidTest/java/ru/pravbeseda/currencyedittext/CalculatorPanelThemeTest.kt
@@ -16,70 +16,101 @@
 package ru.pravbeseda.currencyedittext
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
-import android.view.View
-import android.widget.Button
 import android.widget.FrameLayout
-import android.widget.TextView
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import ru.pravbeseda.currencyedittext.calculator.CalculatorColors
 
-/** The panel must take its colours from the host app's Material theme, not from the platform's. */
+/**
+ * The panel's colours come from the host: its own theme where it says nothing, and the style it
+ * points [R.attr.currencyCalculatorStyle] at where it does. The defaults must resolve under any
+ * theme — a Material-only attribute crashes the inflater in an AppCompat app.
+ */
 class CalculatorPanelThemeTest {
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    private val themed =
-        ContextThemeWrapper(
-            context,
-            com.google.android.material.R.style.Theme_Material3_DayNight,
-        )
-
-    private val panel: View =
-        LayoutInflater
-            .from(themed)
-            .inflate(R.layout.currency_calculator_panel, FrameLayout(themed), false)
-
     @Test
-    fun digitKeysUseTheThemesOnSurfaceColor() {
-        val key = panel.findViewById<Button>(R.id.currency_calculator_key_7)
-        assertEquals(colorOf(com.google.android.material.R.attr.colorOnSurface), key.currentTextColor)
+    fun theDefaultsComeFromTheHostThemeUnderAppCompat() {
+        val themed = themed(androidx.appcompat.R.style.Theme_AppCompat_Light_NoActionBar)
+        val colors = CalculatorColors.of(themed)
+
+        assertEquals(themed.color(android.R.attr.colorBackground), colors.panelBackground.defaultColor)
+        assertEquals(themed.color(android.R.attr.textColorPrimary), colors.keyText.defaultColor)
+        assertEquals(themed.color(android.R.attr.textColorPrimary), colors.expressionText.defaultColor)
+        assertEquals(themed.color(androidx.appcompat.R.attr.colorPrimary), colors.operatorText.defaultColor)
+        assertEquals(ERROR_RED, colors.errorText.defaultColor)
     }
 
     @Test
-    fun operatorKeysUseTheThemesPrimaryColor() {
-        val key = panel.findViewById<Button>(R.id.currency_calculator_key_plus)
-        assertEquals(colorOf(androidx.appcompat.R.attr.colorPrimary), key.currentTextColor)
-    }
+    fun theDefaultsFollowAMaterialTheme() {
+        val themed = themed(com.google.android.material.R.style.Theme_Material3_DayNight)
+        val colors = CalculatorColors.of(themed)
 
-    @Test
-    fun theExpressionLineUsesTheThemesOnSurfaceColor() {
-        val expression = panel.findViewById<TextView>(R.id.currency_calculator_expression)
         assertEquals(
-            colorOf(com.google.android.material.R.attr.colorOnSurface),
-            expression.textColors.defaultColor,
+            themed.color(com.google.android.material.R.attr.colorOnSurface),
+            colors.keyText.defaultColor,
         )
+        assertEquals(
+            themed.color(androidx.appcompat.R.attr.colorPrimary),
+            colors.operatorText.defaultColor,
+        )
+    }
+
+    @Test
+    fun aHostStyleRepaintsTheRolesItNamesAndLeavesTheRest() {
+        val themed = themed(ru.pravbeseda.currencyedittext.test.R.style.TestThemeWithCalculatorOverride)
+        val colors = CalculatorColors.of(themed)
+
+        assertEquals(Color.parseColor("#FF102030"), colors.panelBackground.defaultColor)
+        assertEquals(Color.parseColor("#FF00FF00"), colors.operatorText.defaultColor)
+        assertEquals(themed.color(android.R.attr.textColorPrimary), colors.keyText.defaultColor)
+        assertEquals(ERROR_RED, colors.errorText.defaultColor)
     }
 
     @Test
     fun aDisabledKeyIsDimmed() {
-        val key = panel.findViewById<Button>(R.id.currency_calculator_key_sign)
-        val enabled = key.currentTextColor
-        // The button's state list animator refuses to run off a Looper thread.
-        InstrumentationRegistry.getInstrumentation().runOnMainSync { key.isEnabled = false }
+        val colors = CalculatorColors.of(themed(androidx.appcompat.R.style.Theme_AppCompat_Light_NoActionBar))
+
         assertTrue(
-            "a disabled key must not look like a live one",
-            Color.alpha(key.currentTextColor) < Color.alpha(enabled),
+            "the sign key is disabled where negative values are not allowed, and must look it",
+            Color.alpha(colors.operatorText.disabled()) < Color.alpha(colors.operatorText.defaultColor),
         )
     }
 
-    private fun colorOf(attr: Int): Int {
+    @Test
+    fun thePanelInflatesUnderAnAppCompatTheme() {
+        val themed = themed(androidx.appcompat.R.style.Theme_AppCompat_Light_NoActionBar)
+
+        LayoutInflater
+            .from(themed)
+            .inflate(R.layout.currency_calculator_panel, FrameLayout(themed), false)
+    }
+
+    private fun themed(theme: Int) = ContextThemeWrapper(context, theme)
+
+    private fun Context.color(attr: Int): Int {
         val value = TypedValue()
-        check(themed.theme.resolveAttribute(attr, value, true)) { "attribute $attr is not in the theme" }
-        return if (value.resourceId != 0) themed.getColor(value.resourceId) else value.data
+        check(theme.resolveAttribute(attr, value, true)) { "attribute $attr is not in the theme" }
+        return if (value.resourceId != 0) {
+            requireNotNull(
+                androidx.core.content.ContextCompat
+                    .getColorStateList(this, value.resourceId),
+            ).defaultColor
+        } else {
+            value.data
+        }
+    }
+
+    private fun ColorStateList.disabled(): Int = getColorForState(intArrayOf(-android.R.attr.state_enabled), defaultColor)
+
+    private companion object {
+        const val ERROR_RED = 0xFFB00020.toInt()
     }
 }

--- a/library/src/androidTest/res/values/styles.xml
+++ b/library/src/androidTest/res/values/styles.xml
@@ -14,10 +14,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!-- The popup's own background: a PopupWindow needs one to dismiss on an outside tap. The colour
-     is a placeholder; the panel tints this drawable with calculatorPanelBackgroundColor. -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@android:color/white" />
-    <corners android:radius="8dp" />
-</shape>
+<resources>
+
+    <!-- A host theme that repaints two of the five roles and leaves the rest to the library. -->
+    <style name="TestThemeWithCalculatorOverride" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="currencyCalculatorStyle">@style/TestCalculatorOverride</item>
+    </style>
+
+    <style name="TestCalculatorOverride" parent="">
+        <item name="calculatorPanelBackgroundColor">#FF102030</item>
+        <item name="calculatorOperatorTextColor">#FF00FF00</item>
+    </style>
+
+</resources>

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorColors.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorColors.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import android.content.Context
+import android.content.res.ColorStateList
+import ru.pravbeseda.currencyedittext.R
+
+/**
+ * The panel's colours, read from the host's [R.attr.currencyCalculatorStyle] over the library's own
+ * defaults, so a host that sets nothing still gets a panel that resolves under any theme.
+ */
+internal data class CalculatorColors(
+    val panelBackground: ColorStateList,
+    val expressionText: ColorStateList,
+    val errorText: ColorStateList,
+    val keyText: ColorStateList,
+    val operatorText: ColorStateList,
+) {
+    companion object {
+        /**
+         * A host names the roles it cares about and leaves the rest: `defStyleRes` is consulted
+         * only when `defStyleAttr` resolves to nothing, so the defaults are read as their own pass
+         * and the host's style is laid over them role by role.
+         */
+        fun of(context: Context): CalculatorColors {
+            val defaults =
+                context.obtainStyledAttributes(
+                    null,
+                    R.styleable.CurrencyCalculator,
+                    0,
+                    R.style.Widget_CurrencyEditText_Calculator,
+                )
+            val host =
+                context.obtainStyledAttributes(
+                    null,
+                    R.styleable.CurrencyCalculator,
+                    R.attr.currencyCalculatorStyle,
+                    0,
+                )
+            try {
+                fun role(
+                    index: Int,
+                    name: String,
+                ): ColorStateList =
+                    host.getColorStateList(index)
+                        ?: checkNotNull(defaults.getColorStateList(index)) {
+                            "the library's default calculator style leaves $name unset"
+                        }
+                return CalculatorColors(
+                    panelBackground =
+                        role(
+                            R.styleable.CurrencyCalculator_calculatorPanelBackgroundColor,
+                            "calculatorPanelBackgroundColor",
+                        ),
+                    expressionText =
+                        role(
+                            R.styleable.CurrencyCalculator_calculatorExpressionTextColor,
+                            "calculatorExpressionTextColor",
+                        ),
+                    errorText =
+                        role(
+                            R.styleable.CurrencyCalculator_calculatorErrorTextColor,
+                            "calculatorErrorTextColor",
+                        ),
+                    keyText =
+                        role(
+                            R.styleable.CurrencyCalculator_calculatorKeyTextColor,
+                            "calculatorKeyTextColor",
+                        ),
+                    operatorText =
+                        role(
+                            R.styleable.CurrencyCalculator_calculatorOperatorTextColor,
+                            "calculatorOperatorTextColor",
+                        ),
+                )
+            } finally {
+                host.recycle()
+                defaults.recycle()
+            }
+        }
+    }
+}

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKey.kt
@@ -44,6 +44,13 @@ internal enum class CalculatorKey(
     CLEAR('C'),
 }
 
+/**
+ * Digits and the decimal separator carry the value; every other key acts on it. The panel paints
+ * the two roles in different colours, so each key belongs to exactly one of them.
+ */
+internal val CalculatorKey.isOperator: Boolean
+    get() = !symbol.isDigit() && symbol != '.'
+
 /** Operators the panel prints differently from the ASCII the expression is built out of. */
 private val PRINTED_OPERATORS = mapOf('*' to '\u00d7', '/' to '\u00f7', '-' to '\u2212')
 

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
@@ -20,6 +20,8 @@ import android.graphics.Rect
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.PopupWindow
@@ -94,12 +96,49 @@ internal class CalculatorPopup(
                 isOutsideTouchable = true
                 elevation = anchor.resources.displayMetrics.density * POPUP_ELEVATION_DP
             }
-        showAnchored(content)
+        placeOnceTheKeyboardIsOutOfTheWay(content)
     }
+
+    /**
+     * The panel is measured against the visible window frame, and the popup itself takes focus and
+     * so closes the keyboard: measured before that, the panel is placed against a screen that no
+     * longer exists — flipped above the field and capped to the room the keyboard left. Ask the
+     * keyboard to close first, and place the panel once the frame has answered.
+     */
+    private fun placeOnceTheKeyboardIsOutOfTheWay(content: View) {
+        val frameWithKeyboard = visibleFrame()
+        val keyboardIsClosing =
+            anchor.context
+                .getSystemService(InputMethodManager::class.java)
+                ?.hideSoftInputFromWindow(anchor.windowToken, 0) == true
+        if (!keyboardIsClosing) {
+            showAnchored(content)
+            return
+        }
+
+        var placed = false
+        var onLayout: ViewTreeObserver.OnGlobalLayoutListener? = null
+        val place = {
+            if (!placed) {
+                placed = true
+                onLayout?.let { anchor.viewTreeObserver.removeOnGlobalLayoutListener(it) }
+                if (anchor.isAttachedToWindow) showAnchored(content)
+            }
+        }
+        onLayout =
+            ViewTreeObserver.OnGlobalLayoutListener {
+                if (visibleFrame() != frameWithKeyboard) place()
+            }
+        anchor.viewTreeObserver.addOnGlobalLayoutListener(onLayout)
+        // A keyboard that was already on its way out, or refuses to go, must not hold the panel back.
+        anchor.postDelayed({ place() }, KEYBOARD_CLOSE_TIMEOUT_MS)
+    }
+
+    private fun visibleFrame(): Rect = Rect().also { anchor.getWindowVisibleDisplayFrame(it) }
 
     /** Measures the panel, asks [CalculatorPlacement] where it goes, and shows it there. */
     private fun showAnchored(content: View) {
-        val visible = Rect().also { anchor.getWindowVisibleDisplayFrame(it) }
+        val visible = visibleFrame()
         val anchorTop = IntArray(2).also { anchor.getLocationOnScreen(it) }[1]
         val wanted = measureHeight(content)
         val placement =
@@ -174,5 +213,6 @@ internal class CalculatorPopup(
 
     private companion object {
         const val POPUP_ELEVATION_DP = 8f
+        const val KEYBOARD_CLOSE_TIMEOUT_MS = 300L
     }
 }

--- a/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
+++ b/library/src/main/java/ru/pravbeseda/currencyedittext/calculator/CalculatorPopup.kt
@@ -15,6 +15,7 @@
  */
 package ru.pravbeseda.currencyedittext.calculator
 
+import android.content.res.ColorStateList
 import android.graphics.Rect
 import android.view.LayoutInflater
 import android.view.View
@@ -52,8 +53,6 @@ private val KEY_BUTTONS =
         R.id.currency_calculator_key_clear to CalculatorKey.CLEAR,
     )
 
-private const val ERROR_COLOR = 0xFFB00020.toInt()
-
 private const val EQUALS_LABEL = "="
 
 /**
@@ -71,8 +70,8 @@ internal class CalculatorPopup(
     initialValue: BigDecimal,
     private val onAccept: (BigDecimal) -> Unit,
 ) {
+    private val colors = CalculatorColors.of(anchor.context)
     private var state = CalculatorState.seededWith(initialValue)
-    private var defaultTextColor: Int = 0
     private lateinit var expressionView: TextView
     private lateinit var window: PopupWindow
 
@@ -83,15 +82,14 @@ internal class CalculatorPopup(
                 .inflate(R.layout.currency_calculator_panel, FrameLayout(anchor.context), false)
         bindKeys(content)
         expressionView = content.findViewById(R.id.currency_calculator_expression)
-        defaultTextColor = expressionView.textColors.defaultColor
         render(failed = false)
         window =
             PopupWindow(content, panelWidth(), ViewGroup.LayoutParams.WRAP_CONTENT, true).apply {
                 setBackgroundDrawable(
-                    AppCompatResources.getDrawable(
-                        anchor.context,
-                        R.drawable.currency_calculator_panel_background,
-                    ),
+                    AppCompatResources
+                        .getDrawable(anchor.context, R.drawable.currency_calculator_panel_background)
+                        ?.mutate()
+                        ?.apply { setTintList(colors.panelBackground) },
                 )
                 isOutsideTouchable = true
                 elevation = anchor.resources.displayMetrics.density * POPUP_ELEVATION_DP
@@ -138,6 +136,7 @@ internal class CalculatorPopup(
         KEY_BUTTONS.forEach { (id, key) ->
             content.findViewById<Button>(id).apply {
                 text = key.label(decimalSeparator)
+                setTextColor(if (key.isOperator) colors.operatorText else colors.keyText)
                 // Kept visible but dead, so the panel does not change shape between fields.
                 isEnabled = key != CalculatorKey.SIGN || negativeValueAllow
                 setOnClickListener { press(key) }
@@ -145,6 +144,7 @@ internal class CalculatorPopup(
         }
         content.findViewById<Button>(R.id.currency_calculator_key_equals).apply {
             text = EQUALS_LABEL
+            setTextColor(colors.operatorText)
             setOnClickListener { accept() }
         }
     }
@@ -169,7 +169,7 @@ internal class CalculatorPopup(
 
     private fun render(failed: Boolean) {
         expressionView.text = state.display(decimalSeparator)
-        expressionView.setTextColor(if (failed) ERROR_COLOR else defaultTextColor)
+        expressionView.setTextColor(if (failed) colors.errorText else colors.expressionText)
     }
 
     private companion object {

--- a/library/src/main/res-public/values/attrs.xml
+++ b/library/src/main/res-public/values/attrs.xml
@@ -11,6 +11,22 @@
     <attr name="emptyStringForZero" format="boolean" />
     <attr name="calculatorEnabled" format="boolean" />
 
+    <!-- The style the calculator panel takes its colours from. Set it on the field's own
+         android:theme overlay to give one field its own panel colours. -->
+    <attr name="currencyCalculatorStyle" format="reference" />
+
+    <!-- The colour roles of the calculator panel. Every one of them has a default that resolves
+         under any theme, so a host overrides the ones it cares about and leaves the rest. -->
+    <declare-styleable name="CurrencyCalculator">
+        <attr name="calculatorPanelBackgroundColor" format="reference|color" />
+        <attr name="calculatorExpressionTextColor" format="reference|color" />
+        <attr name="calculatorErrorTextColor" format="reference|color" />
+        <!-- Digits and the decimal separator. -->
+        <attr name="calculatorKeyTextColor" format="reference|color" />
+        <!-- Operators, sign, backspace, clear and equals. -->
+        <attr name="calculatorOperatorTextColor" format="reference|color" />
+    </declare-styleable>
+
     <declare-styleable name="CurrencyEditText">
         <attr name="currencySymbol" />
         <attr name="localeTag" />

--- a/library/src/main/res-public/values/public.xml
+++ b/library/src/main/res-public/values/public.xml
@@ -1,2 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The library's public resource surface: the XML attributes, and nothing else. Naming them here
+     makes the panel's own layout, drawables, colours and styles private to the artifact. -->
 <resources>
+    <public type="attr" name="currencySymbol" />
+    <public type="attr" name="localeTag" />
+    <public type="attr" name="decimalSeparator" />
+    <public type="attr" name="groupingSeparator" />
+    <public type="attr" name="useCurrencySymbolAsHint" />
+    <public type="attr" name="negativeValueAllow" />
+    <public type="attr" name="maxNumberOfDecimalPlaces" />
+    <public type="attr" name="decimalZerosPadding" />
+    <public type="attr" name="emptyStringForZero" />
+    <public type="attr" name="calculatorEnabled" />
+    <public type="attr" name="currencyCalculatorStyle" />
+    <public type="attr" name="calculatorPanelBackgroundColor" />
+    <public type="attr" name="calculatorExpressionTextColor" />
+    <public type="attr" name="calculatorErrorTextColor" />
+    <public type="attr" name="calculatorKeyTextColor" />
+    <public type="attr" name="calculatorOperatorTextColor" />
 </resources>

--- a/library/src/main/res/color/currency_calculator_key_on_surface.xml
+++ b/library/src/main/res/color/currency_calculator_key_on_surface.xml
@@ -14,9 +14,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!-- The popup's own background: a PopupWindow needs one to dismiss on an outside tap. -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?attr/colorSurface" />
-    <corners android:radius="8dp" />
-</shape>
+<!-- A key that is switched off is dimmed, the way the platform button style used to dim it. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:alpha="0.38"
+        android:color="?attr/colorOnSurface"
+        android:state_enabled="false" />
+    <item android:color="?attr/colorOnSurface" />
+</selector>

--- a/library/src/main/res/color/currency_calculator_key_primary.xml
+++ b/library/src/main/res/color/currency_calculator_key_primary.xml
@@ -14,9 +14,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!-- The popup's own background: a PopupWindow needs one to dismiss on an outside tap. -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?attr/colorSurface" />
-    <corners android:radius="8dp" />
-</shape>
+<!-- A key that is switched off is dimmed, the way the platform button style used to dim it. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:alpha="0.38"
+        android:color="?attr/colorPrimary"
+        android:state_enabled="false" />
+    <item android:color="?attr/colorPrimary" />
+</selector>

--- a/library/src/main/res/layout/currency_calculator_panel.xml
+++ b/library/src/main/res/layout/currency_calculator_panel.xml
@@ -37,6 +37,7 @@
             android:paddingEnd="8dp"
             android:paddingTop="12dp"
             android:paddingBottom="12dp"
+            android:textColor="?attr/colorOnSurface"
             android:textSize="20sp" />
 
         <GridLayout
@@ -46,235 +47,88 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_clear"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_open_paren"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_close_paren"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_backspace"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_7"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_8"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_9"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_divide"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_4"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_5"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_6"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_multiply"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_1"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_2"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_3"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_minus"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_sign"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_0"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_decimal"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_plus"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator" />
 
             <Button
                 android:id="@+id/currency_calculator_key_equals"
-                style="?android:attr/borderlessButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_columnSpan="4"
-                android:layout_columnWeight="1"
-                android:layout_gravity="fill_horizontal"
-                android:minHeight="48dp"
-                android:minWidth="0dp"
-                android:textSize="18sp" />
+                style="@style/CurrencyCalculatorKey.Operator"
+                android:layout_columnSpan="4" />
 
         </GridLayout>
 

--- a/library/src/main/res/layout/currency_calculator_panel.xml
+++ b/library/src/main/res/layout/currency_calculator_panel.xml
@@ -37,7 +37,6 @@
             android:paddingEnd="8dp"
             android:paddingTop="12dp"
             android:paddingBottom="12dp"
-            android:textColor="?attr/colorOnSurface"
             android:textSize="20sp" />
 
         <GridLayout
@@ -47,19 +46,19 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_clear"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_open_paren"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_close_paren"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_backspace"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_7"
@@ -75,7 +74,7 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_divide"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_4"
@@ -91,7 +90,7 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_multiply"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_1"
@@ -107,11 +106,11 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_minus"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_sign"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_0"
@@ -123,11 +122,11 @@
 
             <Button
                 android:id="@+id/currency_calculator_key_plus"
-                style="@style/CurrencyCalculatorKey.Operator" />
+                style="@style/CurrencyCalculatorKey" />
 
             <Button
                 android:id="@+id/currency_calculator_key_equals"
-                style="@style/CurrencyCalculatorKey.Operator"
+                style="@style/CurrencyCalculatorKey"
                 android:layout_columnSpan="4" />
 
         </GridLayout>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -14,11 +14,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!-- A key that is switched off is dimmed, the way the platform button style used to dim it. -->
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:alpha="0.38"
-        android:color="?attr/colorOnSurface"
-        android:state_enabled="false" />
-    <item android:color="?attr/colorOnSurface" />
-</selector>
+<resources>
+
+    <!-- The panel's error red, kept out of the theme: ?attr/colorError exists only under Material. -->
+    <color name="currency_calculator_error">#FFB00020</color>
+
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -16,22 +16,25 @@
 -->
 <resources>
 
-    <!-- Geometry shared by every calculator key; the colours come from the host app's theme. -->
-    <style name="CurrencyCalculatorKey">
+    <!-- The panel's default colours. Every default resolves under any theme, Material or not; a
+         host overrides any subset through the currencyCalculatorStyle theme attribute. -->
+    <style name="Widget.CurrencyEditText.Calculator" parent="">
+        <item name="calculatorPanelBackgroundColor">?android:attr/colorBackground</item>
+        <item name="calculatorExpressionTextColor">?android:attr/textColorPrimary</item>
+        <item name="calculatorErrorTextColor">@color/currency_calculator_error</item>
+        <item name="calculatorKeyTextColor">?android:attr/textColorPrimary</item>
+        <item name="calculatorOperatorTextColor">@color/currency_calculator_key_primary</item>
+    </style>
+
+    <!-- Geometry shared by every calculator key; the colours are set from the style above. -->
+    <style name="CurrencyCalculatorKey" parent="@android:style/Widget.Material.Button.Borderless">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_columnWeight">1</item>
         <item name="android:layout_gravity">fill_horizontal</item>
-        <item name="android:background">?attr/selectableItemBackground</item>
         <item name="android:minHeight">48dp</item>
         <item name="android:minWidth">0dp</item>
         <item name="android:textSize">18sp</item>
-        <item name="android:textColor">@color/currency_calculator_key_on_surface</item>
-    </style>
-
-    <!-- Operators, sign, backspace, clear and equals: set apart the way a calculator sets them apart. -->
-    <style name="CurrencyCalculatorKey.Operator">
-        <item name="android:textColor">@color/currency_calculator_key_primary</item>
     </style>
 
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2022-2023 Alexander Ivanov
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<resources>
+
+    <!-- Geometry shared by every calculator key; the colours come from the host app's theme. -->
+    <style name="CurrencyCalculatorKey">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_columnWeight">1</item>
+        <item name="android:layout_gravity">fill_horizontal</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:minHeight">48dp</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">@color/currency_calculator_key_on_surface</item>
+    </style>
+
+    <!-- Operators, sign, backspace, clear and equals: set apart the way a calculator sets them apart. -->
+    <style name="CurrencyCalculatorKey.Operator">
+        <item name="android:textColor">@color/currency_calculator_key_primary</item>
+    </style>
+
+</resources>

--- a/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKeyRoleTest.kt
+++ b/library/src/test/java/ru/pravbeseda/currencyedittext/calculator/CalculatorKeyRoleTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022-2023 Alexander Ivanov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.pravbeseda.currencyedittext.calculator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** The panel paints the two roles differently, so every key belongs to exactly one of them. */
+class CalculatorKeyRoleTest {
+    private val value =
+        setOf(
+            CalculatorKey.DIGIT_0,
+            CalculatorKey.DIGIT_1,
+            CalculatorKey.DIGIT_2,
+            CalculatorKey.DIGIT_3,
+            CalculatorKey.DIGIT_4,
+            CalculatorKey.DIGIT_5,
+            CalculatorKey.DIGIT_6,
+            CalculatorKey.DIGIT_7,
+            CalculatorKey.DIGIT_8,
+            CalculatorKey.DIGIT_9,
+            CalculatorKey.DECIMAL,
+        )
+
+    @Test
+    fun `digits and the decimal separator are the value, every other key acts on it`() {
+        CalculatorKey.entries.forEach { key ->
+            assertEquals("$key", key !in value, key.isOperator)
+        }
+    }
+}

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+    <color name="calculatorPanel">#FFF3F0F4</color>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -8,8 +8,17 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <!-- The overlay this one field is themed with: it also names the calculator panel's style,
+         which is how a host gives a single field its own panel colours. -->
     <style name="CustomThemeEditText">
         <item name="colorAccent">@color/colorPrimary</item>
+        <item name="currencyCalculatorStyle">@style/SampleCalculator</item>
+    </style>
+
+    <!-- Two of the five roles repainted; the other three keep the library's defaults. -->
+    <style name="SampleCalculator" parent="">
+        <item name="calculatorOperatorTextColor">@color/colorAccent</item>
+        <item name="calculatorPanelBackgroundColor">@color/calculatorPanel</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Two defects of the calculator panel, both reported from a Material3 app: the panel opened clipped to a few key rows, and it painted itself in the platform's default purple instead of the app's colours.

## What changed

**Placement.** `CalculatorPopup` measured `getWindowVisibleDisplayFrame()` while the soft keyboard was still up, and the popup — `focusable = true` — then closed that keyboard itself. The panel was placed against a screen that no longer existed: flipped above the field and capped to the room the keyboard had left, so its scroll view showed about two rows. It now asks the keyboard to close first and places the panel once the window frame has answered, with a timeout for the case where no keyboard was open.

**Colours.** The keys used `?android:attr/borderlessButtonStyle` and the background `?android:attr/colorBackground`, which a Material3 theme does not fill in. Material attributes were the first fix and were reversed: `?attr/colorSurface` and `?attr/colorOnSurface` are declared only by Material, and under an AppCompat theme — the one `:sample` itself uses — inflating the panel throws `InflateException`. Instead the panel now reads five colour roles from a style the host points `currencyCalculatorStyle` at, over defaults that resolve under any theme.

## Public API change

New public XML attributes: `currencyCalculatorStyle`, plus the five roles of `<declare-styleable name=\"CurrencyCalculator\">` — `calculatorPanelBackgroundColor`, `calculatorExpressionTextColor`, `calculatorErrorTextColor`, `calculatorKeyTextColor`, `calculatorOperatorTextColor`. A host names the roles it wants and leaves the rest, on the app theme or on the `android:theme` overlay of a single field. Documented in README.

`library/src/main/res-public/values/public.xml` was an empty `<resources/>` and produced no `public.txt` in the AAR, so every library resource was public. It now names the sixteen XML attributes, which makes the panel's layout, drawables, colours and styles private to the artifact. No Kotlin API changed, so `library/api/library.api` is untouched.

## How it was verified

- `./gradlew build` green after `clean`, coverage 81.15% against the 80 floor.
- `:library:connectedAndroidTest` — 23/23 on API 26 and API 36.
- Red before green: `CalculatorKeyRoleTest` (no `isOperator` to compile against), `thePanelInflatesUnderAnAppCompatTheme` (`InflateException`), `aHostStyleRepaintsTheRolesItNamesAndLeavesTheRest` (partial overrides lost four roles until the defaults were read in their own pass — `defStyleRes` is consulted only when `defStyleAttr` resolves to nothing).
- On an API 26 emulator, before the placement fix the panel opened above the field with two of six rows visible and the keyboard still up; after it, the keyboard closes and the panel opens below the field at full height.

No test for the keyboard wait itself: it is IME timing inside a `PopupWindow`, which `src/test` cannot reach and `src/androidTest` has no Espresso or activity rules for. It was verified by hand on the emulator, before and after.

`CalculatorColors` reads the host theme through a `Context`, so it joined `CalculatorPopup` in the Kover exclusion list for the same stated reason; the coverage bound itself is untouched.

Plan and rulings: `.github/tasks/calculator-panel-placement-and-theme.md`.